### PR TITLE
[TITMC] indexes

### DIFF
--- a/app/concepts/data_source/stock/tribunal_commerce/operation/post_import.rb
+++ b/app/concepts/data_source/stock/tribunal_commerce/operation/post_import.rb
@@ -16,7 +16,7 @@ module DataSource
           end
 
           def create_db_indexes(ctx, **)
-            create_queries.each { |query| ActiveRecord::Base.connection.execute(query) }
+            create_queries(:tribunal_commerce).each { |query| ActiveRecord::Base.connection.execute(query) }
           end
 
           def fill_in_foreign_keys(ctx, **)

--- a/app/concepts/data_source/stock/tribunal_instance/operation/post_import.rb
+++ b/app/concepts/data_source/stock/tribunal_instance/operation/post_import.rb
@@ -1,0 +1,25 @@
+module DataSource
+  module Stock
+    module TribunalInstance
+      module Operation
+        class PostImport < Trailblazer::Operation
+          include TrailblazerHelper::DBIndexes
+
+          step :import_completed?
+          fail ->(ctx, logger:, **) { logger.warn 'Import not completed, skipping index creation' }
+          step :create_db_indexes
+          pass ->(ctx, logger:, **) { logger.info 'TITMC indexes created' }
+
+          def import_completed?(ctx, stock_unit:, **)
+            overall_import = stock_unit.stock
+            overall_import.status == 'COMPLETED'
+          end
+
+          def create_db_indexes(ctx, **)
+            create_queries(:tribunal_instance).each { |query| ActiveRecord::Base.connection.execute(query) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/trailblazer_helper/db_indexes.rb
+++ b/app/concepts/trailblazer_helper/db_indexes.rb
@@ -1,8 +1,8 @@
 module TrailblazerHelper
   module DBIndexes
-    def create_queries
+    def create_queries(type_greffe)
       queries = []
-      for_all_indexes do |table, index|
+      for_all_indexes(type_greffe) do |table, index|
         index_name = name_for(table, index)
         index_columns = columns_for(index)
         queries.push("CREATE INDEX IF NOT EXISTS #{index_name} ON #{table} #{index_columns};")
@@ -11,9 +11,9 @@ module TrailblazerHelper
       queries
     end
 
-    def drop_queries
+    def drop_queries(type_greffe)
       queries = []
-      for_all_indexes do |table, index|
+      for_all_indexes(type_greffe) do |table, index|
         index_name = name_for(table, index)
         queries.push("DROP INDEX IF EXISTS #{index_name};")
       end
@@ -28,8 +28,8 @@ module TrailblazerHelper
       Rails.application.config_for(:db_indexes)
     end
 
-    def for_all_indexes
-      configured_indexes.each do |table, indexes|
+    def for_all_indexes(type_greffe)
+      configured_indexes[type_greffe.to_s].each do |table, indexes|
         indexes.each do |index|
           yield(table, index)
         end

--- a/app/concepts/tribunal_commerce/stock/operation/import.rb
+++ b/app/concepts/tribunal_commerce/stock/operation/import.rb
@@ -19,7 +19,7 @@ module TribunalCommerce
         step :import
 
         def drop_db_index(ctx, **)
-          drop_queries.each { |query| ActiveRecord::Base.connection.execute(query) }
+          drop_queries(:tribunal_commerce).each { |query| ActiveRecord::Base.connection.execute(query) }
         end
 
         def stock_exists?(ctx, stock_args:, stocks_folder:, **)

--- a/app/jobs/import_titmc_stock_unit_job.rb
+++ b/app/jobs/import_titmc_stock_unit_job.rb
@@ -22,6 +22,8 @@ class ImportTitmcStockUnitJob < ApplicationJob
 
       if operation.success?
         @stock_unit.update(status: 'COMPLETED')
+        DataSource::Stock::TribunalInstance::Operation::PostImport
+          .call stock_unit: @stock_unit, logger: @logger
       else
         raise ActiveRecord::Rollback
       end

--- a/config/db_indexes.yml
+++ b/config/db_indexes.yml
@@ -1,32 +1,62 @@
 default: &default
-  dossiers_entreprises:
-    - siren
-    - [code_greffe, numero_gestion]
+  tribunal_instance:
+    dossiers_entreprises:
+      - siren
+      - [code_greffe, numero_gestion]
+    titmc_entreprises:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
+    titmc_actes:
+      - code_greffe
+      - entreprise_id
+    titmc_bilans:
+      - code_greffe
+      - entreprise_id
+    titmc_etablissements:
+      - code_greffe
+      - entreprise_id
+    titmc_observations:
+      - code_greffe
+      - entreprise_id
+    titmc_representants:
+      - code_greffe
+      - entreprise_id
+    titmc_adresses:
+      - code_greffe
+      - entreprise_id
+      - etablissement_id
+      - representant_id
 
-  personnes_morales:
-    - siren
-    - [code_greffe, numero_gestion]
-    - dossier_entreprise_id
+  tribunal_commerce:
+    dossiers_entreprises:
+      - siren
+      - [code_greffe, numero_gestion]
 
-  personnes_physiques:
-    - siren
-    - [code_greffe, numero_gestion]
-    - dossier_entreprise_id
+    personnes_morales:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
 
-  representants:
-    - siren
-    - [code_greffe, numero_gestion]
-    - dossier_entreprise_id
+    personnes_physiques:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
 
-  etablissements:
-    - siren
-    - [code_greffe, numero_gestion]
-    - dossier_entreprise_id
+    representants:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
 
-  observations:
-    - siren
-    - [code_greffe, numero_gestion]
-    - dossier_entreprise_id
+    etablissements:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
+
+    observations:
+      - siren
+      - [code_greffe, numero_gestion]
+      - dossier_entreprise_id
 
 development:
   <<: *default

--- a/spec/concepts/data_source/stock/tribunal_commerce/operation/post_import_spec.rb
+++ b/spec/concepts/data_source/stock/tribunal_commerce/operation/post_import_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe DataSource::Stock::TribunalCommerce::Operation::PostImport do
+  subject { described_class.call stock_unit: stock_unit }
+  let(:stock_unit) { stock.stock_units.sample }
+
+  context 'when stock import not completed' do
+    let(:stock) { create :stock_with_one_error_unit }
+
+    it { is_expected.to be_failure }
+  end
+
+  context 'when stock import is completed' do
+    let(:stock) { create :stock_with_completed_units }
+
+    it { is_expected.to be_success }
+    it 'create db indexes'
+    it 'create foreign key link'
+  end
+end

--- a/spec/concepts/data_source/stock/tribunal_instance/operation/load_spec.rb
+++ b/spec/concepts/data_source/stock/tribunal_instance/operation/load_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe DataSource::Stock::TribunalInstance::Operation::Load do
   subject { described_class.call(params) }
 
-  let(:logger) { object_double(Rails.logger, info: true).as_null_object }
+  let(:logger) { instance_double(Logger).as_null_object }
   let(:params) { { logger: logger } }
 
   context 'logger:' do
@@ -25,6 +25,8 @@ describe DataSource::Stock::TribunalInstance::Operation::Load do
     let(:stock_units) { subject[:stock_units] }
 
     it { is_expected.to be_success }
+
+    it 'drop db indexes'
 
     it 'enqueues a job for each greffe found in stock (2 jobs but 3 files)' do
       expect { subject }.to have_enqueued_job(ImportTitmcStockUnitJob)

--- a/spec/concepts/data_source/stock/tribunal_instance/operation/post_import_spec.rb
+++ b/spec/concepts/data_source/stock/tribunal_instance/operation/post_import_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe DataSource::Stock::TribunalInstance::Operation::PostImport do
+  subject { described_class.call stock_unit: stock_unit, logger: logger }
+
+  let(:logger) { instance_double(Logger).as_null_object }
+  let(:stock_unit) { stock.stock_units.sample }
+
+  context 'when stock import not completed' do
+    let(:stock) { create :stock_with_one_error_unit }
+
+    it { is_expected.to be_failure }
+
+    it 'logs a warnning' do
+      expect(logger).to receive(:warn).with('Import not completed, skipping index creation')
+      subject
+    end
+  end
+
+  context 'when stock import is completed' do
+    let(:stock) { create :stock_with_completed_units }
+
+    it { is_expected.to be_success }
+    it 'create db indexes'
+    it 'logs success' do
+      expect(logger).to receive(:info).with('TITMC indexes created')
+      subject
+    end
+  end
+end

--- a/spec/concepts/tribunal_commerce/stock/operation/import_spec.rb
+++ b/spec/concepts/tribunal_commerce/stock/operation/import_spec.rb
@@ -27,12 +27,7 @@ describe TribunalCommerce::Stock::Operation::Import do
 
     it { is_expected.to be_success }
 
-    it 'drops db indexes' do
-      expect_any_instance_of(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
-        .to receive(:execute)
-        .exactly(expected_drop_query_count).times
-      subject
-    end
+    it 'drops db indexes'
 
     it 'creates a job to import each stock unit' do
       stock_unit_ids = new_stock.stock_units.pluck(:id)
@@ -89,15 +84,6 @@ describe TribunalCommerce::Stock::Operation::Import do
         expect { subject }.to not_change(StockTribunalCommerce, :count)
           .and(not_change(StockUnit, :count))
       end
-    end
-
-    def expected_drop_query_count
-      indexes_table = Rails.application.config_for(:db_indexes)
-      indexes_count = indexes_table.inject(0) { |sum, array| sum + array[1].count }
-
-      others_operations_count = 8
-
-      indexes_count + others_operations_count
     end
   end
 


### PR DESCRIPTION
# Que fait cette PR
Ajout de l'étape de suppression/création des indexes pour les TITMC selon la même logique que pour les TC.
Le fichier de conf a été séparé en 2 parties, la configuration pour la table commune `DossierEntreprise` est dupliqué volontairement.

# Commentaires
Suppression des tests sur le bon fonctionnement des drop/create indexes.
Actuellement c'était `expect(Postgres).to receive(:execute).exactly(X).times`
et X c'était `nombre d'indexes + nombre opération de setup de BDD pour RSpec`
ce type de tests n'est pas vraiment généralisable, car le nombre d'opération en BDD de setup de RSpec varie d'un test à l'autre (6 ou 8 opérations)
Du coup j'ai abandonné cette idée.

# Comment faire la review
Commits par commits, mais ça se fait bien aussi d'un coup