### PR TITLE
[Sentry] Log only in production

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,5 @@
 Raven.configure do |config|
   config.dsn = Rails.application.credentials.url_sentry
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-  # TODO: remove sandbox when first version is deployed.
-  # but we want data until then
-  config.environments = %w[production sandbox]
+  config.environments = %w[production]
 end


### PR DESCRIPTION
Envoie des erreurs dans Sentry que ne production.

À livrer quand la prod est en route