### PR TITLE
Compute the right DB date (PDF & API)

### DIFF
--- a/app/concepts/entreprise/operation/identity.rb
+++ b/app/concepts/entreprise/operation/identity.rb
@@ -9,7 +9,7 @@ module Entreprise
         fail :no_exclusif_dossier_principal, fail_fast: true
       step :fetch_etablissement_principal
         fail :no_etablissement_principal
-      step :fetch_db_current_date
+      step Nested TribunalCommerce::DailyUpdate::Operation::DBCurrentDate
       step :fetch_identity_data
 
 
@@ -51,14 +51,6 @@ module Entreprise
 
       def no_etablissement_principal(ctx, **)
         ctx[:http_error] = { code: 500, message: 'Aucun etablissement principal trouvé dans le dossier principal' }
-      end
-
-      # TODO: finish me
-      # pending due to no stock in production
-      def fetch_db_current_date(ctx, **)
-        db_date_operation = TribunalCommerce::DailyUpdate::Operation::DBCurrentDate.call
-        ctx[:db_current_date] = db_date_operation.success? ? db_date_operation[:db_current_date] : nil # <= cannot be nil
-        ctx[:db_current_date] = Date.parse('2018-11-26')
       end
 
       def fetch_identity_data(ctx, dossier_principal:, etablissement_principal:, db_current_date:, **)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 3002 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/spec/controllers/api/infos_identite_entreprise_controller_spec.rb
+++ b/spec/controllers/api/infos_identite_entreprise_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe API::InfosIdentiteEntrepriseController, type: :controller do
+  before { create :daily_update_with_completed_units }
+
   describe '#show' do
     subject do
       get :show, params: { siren: siren }


### PR DESCRIPTION
La date utilisée pour générer le PDF et dans le retour de l'API est maintenant le résultat de l'opération `DBCurrentDate`.
Càd la date du dernier flux TC ou la date du stock TC.

Ça n'est pas idéal cf #89 