### PR TITLE
Set different cron time for daily jobs between environments to avoid conflicts

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@ Sidekiq.configure_server do |config|
   schedule_file = 'config/schedule.yml'
 
   if File.exists?(schedule_file)
-    Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+    loaded_conf = YAML.load_file(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash(loaded_conf[Rails.env])
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,9 +1,22 @@
-sync_ftp_job:
-  cron: '0 0 * * *'
-  class: 'SyncFTPJob'
-  queue: 'auto_updates'
+development:
+  daily_import_tc_job:
+    cron: '0 6 * * *'
+    class: 'DailyImportTCJob'
+    queue: 'auto_updates'
 
-daily_import_tc_job:
-  cron: '0 10 * * *'
-  class: 'DailyImportTCJob'
-  queue: 'auto_updates'
+sandbox:
+  daily_import_tc_job:
+    cron: '0 8 * * *'
+    class: 'DailyImportTCJob'
+    queue: 'auto_updates'
+
+production:
+  sync_ftp_job:
+    cron: '0 0 * * *'
+    class: 'SyncFTPJob'
+    queue: 'auto_updates'
+
+  daily_import_tc_job:
+    cron: '0 10 * * *'
+    class: 'DailyImportTCJob'
+    queue: 'auto_updates'


### PR DESCRIPTION
Sidekiq Cron prevent the same job to be enqued multiple times at the same
time and actually doesn't care about the active job's queue prefix we
use to differentiate queues between instances environments. To fix this
we just run the daily import in sandbox and production at different times.