### PR TITLE
[TITMC] Daily Unit Import

### DIFF
--- a/app/concepts/tribunal_instance/daily_update/task/fetch_units.rb
+++ b/app/concepts/tribunal_instance/daily_update/task/fetch_units.rb
@@ -15,9 +15,9 @@ module TribunalInstance
 
         def deserialize(ctx, daily_update:, units_path:, **)
           daily_update_units = units_path.map do |unit_path|
-            if match = unit_path.match(/\A#{daily_update.files_path}\/(.{12})_\d{14}TITMCFLUX\Z/)
+            if match = unit_path.match(/\A#{daily_update.files_path}\/(.{12})_(\d{14})TITMCFLUX\Z/)
 
-              reference = match.captures.first
+              reference = [match.captures[1], match.captures[0]].join('_')
 
               daily_update.daily_update_units.create(
                 reference: reference,

--- a/app/concepts/tribunal_instance/daily_update/unit/operation/import.rb
+++ b/app/concepts/tribunal_instance/daily_update/unit/operation/import.rb
@@ -3,8 +3,83 @@ module TribunalInstance
     module Unit
       module Operation
         class Import < Trailblazer::Operation
+          pass ->(ctx, logger:, **) { logger.info 'Starting import' }
 
-          pass ->(ctx, **) {}
+          step :parse_xml
+          step :fetch_type
+          step :fetch_code_greffe
+            fail :log_too_many_codes_greffes, fail_fast: true
+          step :fetch_all_data
+          pass :log_trailblazer_mapping_done
+          step :create_associations_dossiers_and_entreprises
+          step :check_file_type
+            fail :log_file_ignored, Output(:success) => 'End.success'
+          step :persist
+            fail :log_operation_fails
+
+          pass ->(ctx, logger:, **) { logger.info 'All valid data persisted' }
+
+          def parse_xml(ctx, path:, **)
+            ctx[:fichier] = TribunalInstance::Fichier.new
+
+            representer   = ::TribunalInstance::FichierRepresenter.new ctx[:fichier]
+            representer.from_xml ::File.read path
+          end
+
+          def fetch_type(ctx, fichier:, **)
+            ctx[:type] = fichier.type
+          end
+
+          def fetch_code_greffe(ctx, fichier:, **)
+            if fichier.greffes.count == 1
+              ctx[:code_greffe] = fichier.greffes.first.code_greffe
+            end
+          end
+
+          def fetch_all_data(ctx, fichier:, **)
+            ctx[:dossiers_entreprises] = fichier.greffes.first.dossiers_entreprises
+            ctx[:entreprises]          = fichier.greffes.first.entreprises
+          end
+
+          def create_associations_dossiers_and_entreprises(ctx, dossiers_entreprises:, entreprises:, **)
+            dossiers_entreprises.each_with_index do |dossier, index|
+              # dossiers_entreprises[index] and entreprise[index] refers to the same company
+              # they are created in the same time by Trailblazer representer
+              # equivalent as : dossier.titmc_entreprise = entreprises.find_by(siren: dossier.siren, numero_gestion: dossier.numero_gestion)
+              # but faster
+              # so we can do this safely:
+              dossier.titmc_entreprise = entreprises[index]
+            end
+          end
+
+          def check_file_type(ctx, type:, **)
+            type == 'RCS'
+          end
+
+          def persist(ctx, dossiers_entreprises:, logger:, **)
+            dossiers_entreprises.each do |dossier|
+              operation = TribunalInstance::DailyUpdate::Unit::Task::PersistRcs
+                .call(dossier: dossier, logger: logger)
+
+              return false if operation.failure?
+            end
+          end
+
+          def log_too_many_codes_greffes(ctx, fichier:, logger:, **)
+            logger.error "Too many code greffe found #{fichier.greffes.count} (#{fichier.greffes.map(&:code_greffe).join(', ')})"
+          end
+
+          def log_trailblazer_mapping_done(ctx, dossiers_entreprises:, logger:, **)
+            logger.info "Trailblazer mapping done #{dossiers_entreprises.count} dossiers found"
+          end
+
+          def log_file_ignored(ctx, type:, logger:, **)
+            logger.info "Ignoring file (#{type}) : #{ctx[:path]}"
+          end
+
+          def log_operation_fails(ctx, logger:, **)
+            logger.error "An operation failed"
+          end
         end
       end
     end

--- a/app/concepts/tribunal_instance/daily_update/unit/task/persist_rcs.rb
+++ b/app/concepts/tribunal_instance/daily_update/unit/task/persist_rcs.rb
@@ -1,0 +1,11 @@
+module TribunalInstance
+  module DailyUpdate
+    module Unit
+      module Task
+        class PersistRcs < Trailblazer::Operation
+
+        end
+      end
+    end
+  end
+end

--- a/app/concepts/tribunal_instance/daily_update/unit/task/persist_rcs.rb
+++ b/app/concepts/tribunal_instance/daily_update/unit/task/persist_rcs.rb
@@ -3,7 +3,46 @@ module TribunalInstance
     module Unit
       module Task
         class PersistRcs < Trailblazer::Operation
+          step ->(ctx, dossier:, **) { !dossier.siren.nil? }
+            fail :log_siren_key_missing, fail_fast: true
+          step ->(ctx, dossier:, **) { !dossier.numero_gestion.nil? }
+            fail :log_numero_gestion_key_missing, fail_fast: true
 
+          step :find_existing_dossier, Output(:failure) => Track(:no_dossier_found)
+          pass :log_deleting_existing_dossier
+          step ->(ctx, existing_dossier:, **) { existing_dossier.destroy }
+
+          pass :log_no_dossier_found, magnetic_to: [:no_dossier_found]
+          step ->(ctx, dossier:, **) { dossier.save }
+          pass :log_dossier_persisted
+
+          def find_existing_dossier(ctx, dossier:, **)
+            ctx[:existing_dossier] = DossierEntreprise.find_by(
+              code_greffe: dossier.code_greffe,
+              numero_gestion: dossier.numero_gestion,
+              siren: dossier.siren
+            )
+          end
+
+          def log_dossier_persisted(ctx, dossier:, logger:, **)
+            logger.info "Dossier persisted id: #{dossier.id} (siren: #{dossier.siren}, numéro gestion: #{dossier.numero_gestion}, code greffe: #{dossier.code_greffe}"
+          end
+
+          def log_no_dossier_found(ctx, logger:, **)
+            logger.info 'No dossier found, creating it...'
+          end
+
+          def log_deleting_existing_dossier(ctx, logger:, **)
+            logger.info "Existing dossier found, deleting it..."
+          end
+
+          def log_siren_key_missing(ctx, dossier:, logger:, **)
+            logger.error "Siren is missing for this dossier numéro gestion: #{dossier.numero_gestion}"
+          end
+
+          def log_numero_gestion_key_missing(ctx, dossier:, logger:, **)
+            logger.error "Numéro gestion is missing for this dossier siren: #{dossier.siren}"
+          end
         end
       end
     end

--- a/app/concepts/tribunal_instance/stock/unit/operation/import.rb
+++ b/app/concepts/tribunal_instance/stock/unit/operation/import.rb
@@ -3,11 +3,7 @@ module TribunalInstance
     module Unit
       module Operation
         class Import < Trailblazer::Operation
-          extend ClassDependencies
-
-          BATCH_SIZE         = 5_000
-          self[:fichier]     = TribunalInstance::Fichier.new
-          self[:representer] = ::TribunalInstance::FichierRepresenter.new self[:fichier]
+          BATCH_SIZE = 5_000
 
           pass ->(ctx, logger:, **) { logger.info 'Starting import' }
 
@@ -24,8 +20,10 @@ module TribunalInstance
           step :persist
           pass ->(ctx, logger:, **) { logger.info 'All data persisted' }
 
+          def parse_xml(ctx, path:, **)
+            ctx[:fichier]     = TribunalInstance::Fichier.new
 
-          def parse_xml(ctx, path:, representer:, **)
+            representer = ::TribunalInstance::FichierRepresenter.new ctx[:fichier]
             representer.from_xml ::File.read path
           end
 

--- a/app/concepts/tribunal_instance/stock/unit/operation/import.rb
+++ b/app/concepts/tribunal_instance/stock/unit/operation/import.rb
@@ -6,8 +6,7 @@ module TribunalInstance
           extend ClassDependencies
 
           BATCH_SIZE         = 5_000
-          Fichier            = Struct.new(:greffes)
-          self[:fichier]     = Fichier.new
+          self[:fichier]     = TribunalInstance::Fichier.new
           self[:representer] = ::TribunalInstance::FichierRepresenter.new self[:fichier]
 
           pass ->(ctx, logger:, **) { logger.info 'Starting import' }

--- a/app/concepts/zip/operation/extract.rb
+++ b/app/concepts/zip/operation/extract.rb
@@ -1,28 +1,38 @@
 require 'open3'
+require 'securerandom'
 
 module ZIP
   module Operation
     class Extract < Trailblazer::Operation
       step :setup_context
+      step :check_directory_does_not_exist_yet
+        fail :log_dir_already_exists
       step :unzip
-      fail :log_unzip_failed
+        fail :log_unzip_failed
       step :fetch_unzip_files
 
       def setup_context(ctx, path:, **)
         ctx[:filename]       = Pathname.new(path).basename('.zip')
-        ctx[:dest_directory] = "#{Rails.root}/tmp/#{ctx[:filename]}"
+        ctx[:dest_directory] = "#{Rails.root}/tmp/#{ctx[:filename]}_#{SecureRandom.hex(3)}"
+      end
+
+      def check_directory_does_not_exist_yet(ctx, dest_directory:, **)
+        !Pathname.new(dest_directory).exist?
+      end
+
+      def log_dir_already_exists(ctx, **)
+        ctx[:error] = 'Destination directory already exists'
       end
 
       def unzip(ctx, path:, dest_directory:, **)
-        # -o overrides existing files (removes unix prompt for override)
-        _stdout, stderr, status = ::Open3.capture3 "unzip -o #{path} -d #{dest_directory}"
+        _stdout, stderr, status = ::Open3.capture3 "unzip #{path} -d #{dest_directory}"
 
         ctx[:zip_stderr] = stderr
         status.success?
       end
 
-      def log_unzip_failed(ctx, zip_stderr:, **)
-        ctx[:error] = zip_stderr
+      def log_unzip_failed(ctx, **)
+        ctx[:error] ||= ctx[:zip_stderr]
       end
 
       def fetch_unzip_files(ctx, dest_directory:, **)

--- a/app/models/tribunal_instance/fichier.rb
+++ b/app/models/tribunal_instance/fichier.rb
@@ -1,0 +1,1 @@
+TribunalInstance::Fichier = Struct.new(:type, :greffes)

--- a/app/representers/tribunal_instance/fichier_representer.rb
+++ b/app/representers/tribunal_instance/fichier_representer.rb
@@ -3,6 +3,8 @@ class TribunalInstance::FichierRepresenter < Representable::Decorator
 
   remove_namespaces!
 
+  property :type, attribute: true
+
   collection :greffes,
     as: :grf,
     wrap: false,

--- a/spec/concepts/tribunal_commerce/partial_stock_unit/operation/load_spec.rb
+++ b/spec/concepts/tribunal_commerce/partial_stock_unit/operation/load_spec.rb
@@ -24,7 +24,7 @@ describe TribunalCommerce::PartialStockUnit::Operation::Load, :trb do
 
   after do
     # Clean unit extraction directory
-    FileUtils.rm_rf(Rails.root.join('tmp/0384_S2_20180409'))
+    FileUtils.rm_rf(Rails.root.join(subject[:dest_directory]))
   end
 
   it 'logs that the import starts' do
@@ -46,13 +46,13 @@ describe TribunalCommerce::PartialStockUnit::Operation::Load, :trb do
       unit_files = subject[:extracted_files]
 
       expect(unit_files).to contain_exactly(
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_1_PM.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_3_PP.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_5_rep.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_8_ets.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_11_obs.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_12_actes.csv'),
-        a_string_ending_with('tmp/0384_S2_20180409/0384_S2_20180409_13_comptes_annuels.csv'),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_1_PM.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_3_PP.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_5_rep.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_8_ets.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_11_obs.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_12_actes.csv/),
+        a_string_matching(/tmp\/0384_S2_20180409_.{6}\/0384_S2_20180409_13_comptes_annuels.csv/),
       )
     end
 

--- a/spec/concepts/tribunal_instance/daily_update/task/fetch_units_spec.rb
+++ b/spec/concepts/tribunal_instance/daily_update/task/fetch_units_spec.rb
@@ -27,11 +27,11 @@ describe TribunalInstance::DailyUpdate::Task::FetchUnits do
       references = subject[:daily_update_units].pluck(:reference)
 
       expect(references).to contain_exactly(
-        '0O09IEJ9562u',
-        '0qLllJmhaRhU',
-        '0NKxyI4J7iuk',
-        '0Hnni3p82a62',
-        '1eUKHhoF3kQT'
+        '20170504204802_0O09IEJ9562u',
+        '20170509212412_0Hnni3p82a62',
+        '20170515205704_1eUKHhoF3kQT',
+        '20170516221805_0qLllJmhaRhU',
+        '20170517210602_0NKxyI4J7iuk'
       )
     end
 

--- a/spec/concepts/tribunal_instance/daily_update/unit/operation/import_spec.rb
+++ b/spec/concepts/tribunal_instance/daily_update/unit/operation/import_spec.rb
@@ -1,5 +1,83 @@
 require 'rails_helper'
 
-describe TribunalInstance::DailyUpdate::Unit::Operation::Import do
+describe TribunalInstance::DailyUpdate::Unit::Operation::Import, :trb do
+  subject { described_class.call path: path, logger: logger }
 
+  let(:logger) { instance_double(Logger).as_null_object }
+  let(:path) { Rails.root.join 'spec', 'fixtures', 'titmc', 'xml', filename }
+
+  describe 'success import' do
+    let(:filename) { 'flux_RCS.xml' }
+
+    before do
+      allow(TribunalInstance::DailyUpdate::Unit::Task::PersistRcs)
+        .to receive(:call)
+        .and_return(trb_result_success)
+    end
+
+    it { is_expected.to be_success }
+
+    it 'logs' do
+      expect(logger).to receive(:info).with('Starting import')
+      subject
+    end
+
+    its([:type])                 { is_expected.to eq 'RCS' }
+    its([:dossiers_entreprises]) { are_expected.to all have_attributes code_greffe: '9741' }
+    its([:dossiers_entreprises]) { are_expected.to all have_attributes nom_greffe: 'St Denis de la Réunion' }
+    its([:dossiers_entreprises]) { are_expected.to all have_attributes titmc_entreprise: be_a(TribunalInstance::Entreprise) }
+
+    it 'calls Task::Persist 3 times' do
+      expect(TribunalInstance::DailyUpdate::Unit::Task::PersistRcs)
+        .to receive(:call)
+        .exactly(3).times
+      subject
+    end
+  end
+
+  describe 'ACT file type' do
+    let(:filename) { 'flux_ACT.xml' }
+
+    its([:type]) { is_expected.to eq 'ACT' }
+
+    it { is_expected.to be_success }
+
+    it 'logs that the file is ignored' do
+      expect(logger).to receive(:info).with(/Ignoring file \(ACT\) : .+#{filename}/)
+      subject
+    end
+
+    it 'does not call PersisRcs' do
+      expect(TribunalInstance::DailyUpdate::Unit::Task::PersistRcs).not_to receive(:call)
+      subject
+    end
+  end
+
+  describe 'multi greffe file' do
+    let(:filename) { 'flux_multi_greffes.xml' }
+
+    it { is_expected.to be_failure }
+
+    it 'logs an error' do
+      expect(logger).to receive(:error).with('Too many code greffe found 2 (1111, 2222)')
+      subject
+    end
+  end
+
+  describe 'import fails' do
+    let(:filename) { 'flux_RCS.xml' }
+
+    before do
+      allow(TribunalInstance::DailyUpdate::Unit::Task::PersistRcs)
+        .to receive(:call)
+        .and_return(trb_result_failure)
+    end
+
+    it { is_expected.to be_failure }
+
+    it 'logs an error' do
+      expect(logger).to receive(:error).with('An operation failed')
+      subject
+    end
+  end
 end

--- a/spec/concepts/tribunal_instance/daily_update/unit/operation/load_transmission_spec.rb
+++ b/spec/concepts/tribunal_instance/daily_update/unit/operation/load_transmission_spec.rb
@@ -9,12 +9,18 @@ describe TribunalInstance::DailyUpdate::Unit::Operation::LoadTransmission, :trb 
   context 'when zip exists' do
     let(:filename) { '20170509212412TITMCFLUX.zip' }
 
-    it 'logs import start' do
-      expect(logger).to receive(:info).with(/Starting import of transmission: .+20170509212412TITMCFLUX.zip/)
-      subject
-    end
-
     context 'when import is successful' do
+      before do
+        allow(TribunalInstance::DailyUpdate::Unit::Operation::Import)
+          .to receive(:call)
+          .and_return(trb_result_success)
+      end
+
+      it 'logs import start' do
+        expect(logger).to receive(:info).with(/Starting import of transmission: .+20170509212412TITMCFLUX.zip/)
+        subject
+      end
+
       it { is_expected.to be_success }
 
       it 'calls Import operation with success' do

--- a/spec/concepts/tribunal_instance/daily_update/unit/task/persist_rcs_spec.rb
+++ b/spec/concepts/tribunal_instance/daily_update/unit/task/persist_rcs_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe TribunalInstance::DailyUpdate::Unit::Task::PersistRcs do
+end

--- a/spec/concepts/tribunal_instance/daily_update/unit/task/persist_rcs_spec.rb
+++ b/spec/concepts/tribunal_instance/daily_update/unit/task/persist_rcs_spec.rb
@@ -1,4 +1,114 @@
 require 'rails_helper'
 
 describe TribunalInstance::DailyUpdate::Unit::Task::PersistRcs do
+  subject { described_class.call dossier: dossier, logger: logger }
+
+  let(:logger) { instance_double(Logger).as_null_object }
+  let(:path) { Rails.root.join 'spec/fixtures/titmc/xml/flux_RCS.xml' }
+
+  let(:greffe) do
+    greffe = TribunalInstance::FichierRepresenter
+      .new(TribunalInstance::Fichier.new)
+      .from_xml(File.read(path.to_s))
+      .greffes.first
+  end
+
+  let(:dossiers) do
+    greffe.dossiers_entreprises.each_with_index do |dossier, index|
+      dossier.titmc_entreprise = greffe.entreprises[index]
+    end
+
+    greffe.dossiers_entreprises
+  end
+
+  shared_examples 'dossier persisted' do
+    it { is_expected.to be_success }
+
+    it 'logs' do
+      expect(logger).to receive(:info).with(/Dossier persisted id: .+/)
+      subject
+    end
+
+    its([:dossier]) { is_expected.to be_persisted }
+
+    it 'persists adresse siège' do
+      expect { subject }.to change(TribunalInstance::AdresseSiege, :count).by 1
+    end
+
+    it 'persists adresse representant' do
+      expect { subject }.to change(TribunalInstance::AdresseRepresentant, :count).by 1
+    end
+
+    it 'persists entreprise' do
+      expect { subject }.to change(TribunalInstance::Entreprise, :count).by 1
+    end
+
+    it 'persists établissement' do
+      expect { subject }.to change(TribunalInstance::Etablissement, :count).by 1
+    end
+
+    it 'persists observations' do
+      expect { subject }.to change(TribunalInstance::Observation, :count).by 2
+    end
+
+    it 'persists représentant' do
+      expect { subject }.to change(TribunalInstance::Representant, :count).by 1
+    end
+  end
+
+  context 'when dossier is not found' do
+    let(:dossier) { dossiers.find { |d| d.siren == '819356163' } }
+
+    it 'logs' do
+      expect(logger).to receive(:info).with('No dossier found, creating it...')
+      subject
+    end
+
+    it_behaves_like 'dossier persisted'
+  end
+
+  context 'when dossier already exists' do
+    let!(:existing_dossier) do
+      create :dossier_entreprise,
+        code_greffe: dossier.code_greffe,
+        numero_gestion: dossier.numero_gestion,
+        siren: dossier.siren
+    end
+
+    let(:dossier) { dossiers.find { |d| d.siren == '819356163' } }
+
+    it 'logs' do
+      expect(logger).to receive(:info).with('Existing dossier found, deleting it...')
+      subject
+    end
+
+    it 'destroy existing dossier' do
+      subject
+      expect { existing_dossier.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it_behaves_like 'dossier persisted'
+  end
+
+  context 'when key numéro gestion is missing' do
+    let(:dossier) { dossiers.find { |d| d.siren == 'missing numero gestion' } }
+
+    it { is_expected.to be_failure }
+
+    it 'logs an error' do
+      expect(logger).to receive(:error).with(/Numéro gestion is missing for this dossier siren: .+/)
+      subject
+    end
+  end
+
+  context 'when key siren is missing' do
+    let(:dossier) { dossiers.find { |d| d.numero_gestion == 'missing siren' } }
+
+    it { is_expected.to be_failure }
+
+    it 'logs an error' do
+      expect(logger).to receive(:error).with(/Siren is missing for this dossier numéro gestion: .+/)
+      subject
+    end
+  end
 end

--- a/spec/concepts/tribunal_instance/stock/unit/operation/import_spec.rb
+++ b/spec/concepts/tribunal_instance/stock/unit/operation/import_spec.rb
@@ -16,6 +16,7 @@ describe TribunalInstance::Stock::Unit::Operation::Import, :trb do
 
     its([:dossiers_entreprises]) { are_expected.to all be_persisted }
     its([:dossiers_entreprises]) { are_expected.to all have_attributes code_greffe: '9712' }
+    its([:dossiers_entreprises]) { are_expected.to all have_attributes nom_greffe: 'Pointe-à-Pitre' }
     its([:dossiers_entreprises]) { are_expected.to all have_attributes titmc_entreprise: be_a(TribunalInstance::Entreprise) }
 
     it 'persists 2 entreprises' do

--- a/spec/concepts/zip/operation/extract_spec.rb
+++ b/spec/concepts/zip/operation/extract_spec.rb
@@ -1,25 +1,22 @@
 require 'rails_helper'
 
 describe ZIP::Operation::Extract do
-  # TODO deal with not valid files (thinking about :group operation option)
-  # TODO deal with unzip errors
-
   # Archive manually created for tests.
   # Contains files :
   #  - example.csv
   #  - file_1.txt
   #  - wow.example
   #  - very_nested/test.xml
+  let(:random_string) { 'aZeRtY' }
   let(:zip_path) { Rails.root.join('spec', 'concepts', 'zip', 'example.zip').to_s }
-  let(:dest_directory) { Rails.root.join('tmp', 'example').to_s }
+  let(:dest_directory) { Rails.root.join('tmp', 'example_' + random_string).to_s }
 
   subject { described_class.call(path: zip_path) }
 
+  before { allow(SecureRandom).to receive(:hex).and_return random_string }
   after { FileUtils.rm_rf(dest_directory) } # clean extracted files
 
-  it 'is successful' do
-    expect(subject).to be_success
-  end
+  it { is_expected.to be_success }
 
   it 'extracts into a directory named from the zip' do
     subject
@@ -52,5 +49,21 @@ describe ZIP::Operation::Extract do
     it { is_expected.to be_failure }
 
     its([:error]) { is_expected.to match /unzip:  cannot find or open .+you_will_never_find_me.+/ }
+  end
+
+  context 'when destination directory already exists' do
+    before { Pathname.new(dest_directory).mkdir }
+
+    it { is_expected.to be_failure }
+
+    its([:error]) { is_expected.to include 'Destination directory already exists' }
+  end
+
+  context 'when zip is invalid' do
+    let(:zip_path) { Rails.root.join('spec', 'concepts', 'zip', 'invalid.zip').to_s }
+
+    it { is_expected.to be_failure }
+
+    its([:error]) { is_expected.to match /this file is not\n.+a zipfile/ }
   end
 end

--- a/spec/fixtures/titmc/xml/flux_ACT.xml
+++ b/spec/fixtures/titmc/xml/flux_ACT.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<fichier type="ACT" version="1.3" xmlns="fr:inpi:odrncs:serpentXML">
+  <grf cod="9721">
+    <societe dat_donnees="20170517" num_gestion="2016D00597">
+      <acts>
+        <act>
+          <type>A1</type>
+          <dat_depot>20161228</dat_depot>
+          <dat_acte>20161024</dat_acte>
+          <num_depot_manuel>11371</num_depot_manuel>
+        </act>
+        <act>
+          <type>AA</type>
+          <nature>DI</nature>
+          <dat_depot>20161228</dat_depot>
+          <dat_acte>20161024</dat_acte>
+          <num_depot_manuel>11371</num_depot_manuel>
+        </act>
+        <act>
+          <type>AD</type>
+          <dat_depot>20161228</dat_depot>
+          <dat_acte>20161024</dat_acte>
+          <num_depot_manuel>11371</num_depot_manuel>
+        </act>
+      </acts>
+    </societe>
+    <societe dat_donnees="20170517" num_gestion="dossier not found">
+      <acts>
+        <act>
+          <type>A1</type>
+          <dat_depot>20170405</dat_depot>
+        </act>
+      </acts>
+    </societe>
+    <societe dat_donnees="20170517" num_gestion="multiple dossiers found">
+      <acts>
+        <act>
+          <type>A1</type>
+          <dat_depot>20161227</dat_depot>
+        </act>
+      </acts>
+    </societe>
+  </grf>
+</fichier>

--- a/spec/fixtures/titmc/xml/flux_BIL.xml
+++ b/spec/fixtures/titmc/xml/flux_BIL.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<fichier type="BIL" version="1.3" xmlns="fr:inpi:odrncs:serpentXML">
+  <grf cod="5751">
+    <societe dat_donnees="20170517" num_gestion="2006B00357">
+      <bils>
+        <bil>
+          <date_cloture_aa>2007</date_cloture_aa>
+          <dat_depot>20080919</dat_depot>
+          <confid_ind>0</confid_ind>
+          <confid_ind_CR>0</confid_ind_CR>
+          <num_depot>3598</num_depot>
+          <dat_cloture_jjmm>3112</dat_cloture_jjmm>
+        </bil>
+        <bil>
+          <date_cloture_aa>2006</date_cloture_aa>
+          <dat_depot>20071008</dat_depot>
+          <confid_ind>0</confid_ind>
+          <confid_ind_CR>0</confid_ind_CR>
+          <num_depot>3821</num_depot>
+          <dat_cloture_jjmm>3112</dat_cloture_jjmm>
+        </bil>
+      </bils>
+    </societe>
+    <societe dat_donnees="20170517" num_gestion="multiple_dossiers">
+      <bils>
+        <bil>
+          <date_cloture_aa>2000</date_cloture_aa>
+          <dat_depot>20020206</dat_depot>
+        </bil>
+      </bils>
+    </societe>
+    <societe dat_donnees="20170517" num_gestion="dossier not found">
+      <bils>
+        <bil>
+          <date_cloture_aa>2000</date_cloture_aa>
+          <dat_depot>20020206</dat_depot>
+        </bil>
+      </bils>
+    </societe>
+  </grf>
+</fichier>

--- a/spec/fixtures/titmc/xml/flux_RCS.xml
+++ b/spec/fixtures/titmc/xml/flux_RCS.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<fichier type="RCS" version="1.3" xmlns="fr:inpi:odrncs:serpentXML">
+  <grf cod="9741">
+    <societe dat_donnees="20170509" num_gestion="2016B00383" siren="819356163">
+      <idt>
+        <rcs>B819356163</rcs>
+        <nom_raison_soc>LES MARMAILLES</nom_raison_soc>
+        <code_form_jur>5499</code_form_jur>
+        <siege>
+          <adr_1>
+            <resid>BEAUSEJOUR</resid>
+            <num_voie>601</num_voie>
+            <type_voie>RUE</type_voie>
+            <nom_voie>FLEUR DE JADE</nom_voie>
+            <cp>97438</cp>
+            <bur_cdx>SAINTE MARIE</bur_cdx>
+          </adr_1>
+        </siege>
+        <immat>
+          <dat>20160407</dat>
+        </immat>
+        <activ>
+          <ape_naf>8891A</ape_naf>
+        </activ>
+        <cap>
+          <montant>500000</montant>
+          <devise>EUR</devise>
+        </cap>
+        <durees>
+          <duree_pm>99</duree_pm>
+          <dat_cloture_jjmm>3112</dat_cloture_jjmm>
+        </durees>
+        <divers>
+          <statut_edit_extrait>B1</statut_edit_extrait>
+        </divers>
+        <prem_exer>
+          <dat_cloture>20161231</dat_cloture>
+        </prem_exer>
+      </idt>
+      <reps>
+        <rep>
+          <qual>0200</qual>
+          <rais_nom>LEBON                                                           AMLIE MARIE CCILE</rais_nom>
+          <nom_denom>LEBON</nom_denom>
+          <prenom>AMLIE MARIE CCILE</prenom>
+          <type_dir>PP</type_dir>
+          <dat_crea_rep>20160401</dat_crea_rep>
+          <adr1>
+            <voie>17 RUE DES SENTEURS</voie>
+            <cp_bur>97412 BRAS PANON</cp_bur>
+          </adr1>
+          <pers_physique>
+            <dat_naiss>19780515</dat_naiss>
+            <lieu_naiss>NICE</lieu_naiss>
+          </pers_physique>
+        </rep>
+      </reps>
+      <etabs>
+        <etab>
+          <categ>PRI</categ>
+          <enseigne>BABYCHOU SERVICES</enseigne>
+          <adr1>
+            <resid>BEAUSEJOUR</resid>
+            <voie>601     RUE FLEUR DE JADE</voie>
+            <cp_bur>97438 SAINTE MARIE</cp_bur>
+          </adr1>
+          <activ>
+            <siret>819356163</siret>
+            <ape_naf>8891A</ape_naf>
+            <orig_fonds>01</orig_fonds>
+          </activ>
+        </etab>
+      </etabs>
+    </societe>
+    <societe dat_donnees="20170509" num_gestion="multiple dossiers found" siren="819537317">
+      <idt>
+        <rcs>B819537317</rcs>
+        <nom_raison_soc>WARANOO</nom_raison_soc>
+        <code_form_jur>5720</code_form_jur>
+      </idt>
+    </societe>
+    <societe dat_donnees="20170509" num_gestion="dossier not found" siren="819959883">
+      <idt>
+        <rcs>B819959883</rcs>
+        <nom_raison_soc>GREGALI</nom_raison_soc>
+        <code_form_jur>5499</code_form_jur>
+      </idt>
+    </societe>
+  </grf>
+</fichier>

--- a/spec/fixtures/titmc/xml/flux_RCS.xml
+++ b/spec/fixtures/titmc/xml/flux_RCS.xml
@@ -71,15 +71,26 @@
           </activ>
         </etab>
       </etabs>
+      <procs>
+        <proc>
+          <code_obs>J41</code_obs>
+          <texte_obs>7600;SELARL DAVID KOCH;;0004 RUE DU CONSEIL SOUVERAIN;;68000;COLMAR;;;0000;0000;;;</texte_obs>
+          <dat_obs>20090908</dat_obs>
+          <num_obs>1</num_obs>
+        </proc>
+        <proc>
+          <num_obs>2</num_obs>
+        </proc>
+      </procs>
     </societe>
-    <societe dat_donnees="20170509" num_gestion="multiple dossiers found" siren="819537317">
+    <societe dat_donnees="20170509" siren="missing numero gestion">
       <idt>
-        <rcs>B819537317</rcs>
-        <nom_raison_soc>WARANOO</nom_raison_soc>
-        <code_form_jur>5720</code_form_jur>
+        <rcs>B819959883</rcs>
+        <nom_raison_soc>GREGALI</nom_raison_soc>
+        <code_form_jur>5499</code_form_jur>
       </idt>
     </societe>
-    <societe dat_donnees="20170509" num_gestion="dossier not found" siren="819959883">
+    <societe dat_donnees="20170509" num_gestion="missing siren">
       <idt>
         <rcs>B819959883</rcs>
         <nom_raison_soc>GREGALI</nom_raison_soc>

--- a/spec/fixtures/titmc/xml/flux_multi_greffes.xml
+++ b/spec/fixtures/titmc/xml/flux_multi_greffes.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<fichier type="BIL" version="1.3" xmlns="fr:inpi:odrncs:serpentXML">
+  <grf cod="1111">
+    <societe dat_donnees="20170517" num_gestion="2006B00357">
+      <bils>
+        <bil>
+          <date_cloture_aa>2007</date_cloture_aa>
+          <dat_depot>20080919</dat_depot>
+        </bil>
+      </bils>
+    </societe>
+  </grf>
+  <grf cod="2222">
+    <societe dat_donnees="20170517" num_gestion="2006B00357">
+      <bils>
+        <bil>
+          <date_cloture_aa>2007</date_cloture_aa>
+          <dat_depot>20080919</dat_depot>
+        </bil>
+      </bils>
+    </societe>
+  </grf>
+</fichier>

--- a/spec/representers/tribunal_instance/fichier_representer_spec.rb
+++ b/spec/representers/tribunal_instance/fichier_representer_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe TribunalInstance::FichierRepresenter, :representer do
   subject { fichier_representer }
 
-  it { is_expected.to be_a RepresenterHelper::RSpec::Fichier }
+  it { is_expected.to be_a TribunalInstance::Fichier }
+  its(:type) { is_expected.to eq 'FULL' }
 
   its(:greffes) { is_expected.to have_attributes count: 2 }
   its(:greffes) { are_expected.to all respond_to :dossiers_entreprises }

--- a/spec/support/helpers/representer.rb
+++ b/spec/support/helpers/representer.rb
@@ -1,12 +1,10 @@
 module RepresenterHelper
   module RSpec
-    Fichier = Struct.new(:greffes)
-
     def fichier_representer
       xml_path = Rails.root.join 'spec', 'fixtures', 'titmc', 'xml', '9712_S1_20180505_lot02.xml'
 
     TribunalInstance::FichierRepresenter
-        .new(Fichier.new)
+        .new(TribunalInstance::Fichier.new)
         .from_xml(File.read(xml_path.to_s))
     end
 

--- a/spec/support/helpers/representer.rb
+++ b/spec/support/helpers/representer.rb
@@ -3,7 +3,7 @@ module RepresenterHelper
     def fichier_representer
       xml_path = Rails.root.join 'spec', 'fixtures', 'titmc', 'xml', '9712_S1_20180505_lot02.xml'
 
-    TribunalInstance::FichierRepresenter
+      TribunalInstance::FichierRepresenter
         .new(TribunalInstance::Fichier.new)
         .from_xml(File.read(xml_path.to_s))
     end


### PR DESCRIPTION
# Ce que fait cette PR
Import effectif des DailyUpdateUnit TITMC.
On ignore les fichiers de flux BIL/ACT on n'importe que les RCS (identité) (~50% sont ignorés)

On opère par annule et remplace.

# Impacts
Chaque jour il y a `n` dossiers de la forme `rAndOm_yyyymmddhhmmss_TITMCFLUX` contenant un fichier de la forme `yyyymmddhhmmss_TITMCFLUX.zip` et bien sûr il y a souvent plusieurs fichiers qui s'appellent pareils. 
Il arrive régulièrement que ces fichiers soient traités en même temps par 2 process Sidekiq différents et donc l'un écrase l'autre provocant des erreurs d'imports.

## Solution proposée ici
L'opération `ZIP::Operation::Extract` extrait les fichiers non plus dans un dossier `filename` mais `filename_rAnDom` et renvoie donc dans `dest_directory` le bon nom.

De plus les erreurs de dossier déjà présent n'étaient pas rattrapés ; l'option `-o` (override) de `unzip` écrasait les fichiers (my bad c'était moi).

Et donc malgré cet ajout d'un random je propose de tester la présence du dossier et de remonter l'erreur.

# Fichiers de log
pour améliorer la recherche dans les noms de logs TITMC ils sont nommés `yyyymmddhhmmss_rAnDom_date_du_jour.log` en référence au nom du fichier traité