### PR TITLE
Use different Redis databases per environments

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,6 +47,9 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
+  # Redis database URL
+  config.redis_database = 'redis://localhost:6379/0'
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,6 +71,9 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Redis database URL
+  config.redis_database = 'redis://localhost:6379/1'
+
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
+  # Redis database URL
+  config.redis_database = 'redis://localhost:6379/0'
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,19 @@
-Sidekiq.configure_server do |config|
+def load_sidekiq_cron_jobs
   schedule_file = 'config/schedule.yml'
 
   if File.exists?(schedule_file)
     loaded_conf = YAML.load_file(schedule_file)
     Sidekiq::Cron::Job.load_from_hash(loaded_conf[Rails.env])
   end
+end
+
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: Rails.configuration.redis_database }
+
+  load_sidekiq_cron_jobs
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: Rails.configuration.redis_database }
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -17,6 +17,6 @@ production:
     queue: 'auto_updates'
 
   daily_import_tc_job:
-    cron: '0 10 * * *'
+    cron: '0 8 * * *'
     class: 'DailyImportTCJob'
     queue: 'auto_updates'


### PR DESCRIPTION
Use a different Redis database per environments to avoid conflicts with
cron jobs orchestration. See https://github.com/ondrejbartas/sidekiq-cron/issues/195
for more details.

Change is also made into the Ansible : Redis database URLs are defined and deployed by ansible.