### PR TITLE
Utilisation de Wget pour la récupération des MAJ quotidiennes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ Create the file `config/rncs_sources.yml` with the content :
 
 ```yaml
 development:
-  path: <YOUR PATH TO SOURCE FILES>
+  path_prefix: <YOUR PATH TO SOURCE FILES>
+  ftp_path_prefix: opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies
   import_batch_size: 5_000
 
 test:
-  path: ./spec/fixtures
+  path_prefix: ./spec/fixtures
+  ftp_path_prefix: ''
   import_batch_size: 3
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Create the file `config/rncs_sources.yml` with the content :
 
 ```yaml
 development:
-  path_prefix: <YOUR PATH TO SOURCE FILES>
+  local_path_prefix: <FOLDER TO SYNC SOURCE FILES TO>
   ftp_path_prefix: opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies
   import_batch_size: 5_000
 
 test:
-  path_prefix: ./spec/fixtures
+  local_path_prefix: ./spec/fixtures
   ftp_path_prefix: ''
   import_batch_size: 3
 ```

--- a/app/concepts/tribunal_commerce/daily_update/operation/fetch_in_pipe.rb
+++ b/app/concepts/tribunal_commerce/daily_update/operation/fetch_in_pipe.rb
@@ -4,7 +4,7 @@ module TribunalCommerce
       class FetchInPipe < Trailblazer::Operation
         extend ClassDependencies
 
-        self[:flux_folder] = ::File.join(Rails.configuration.rncs_sources['path'], 'tc', 'flux')
+        self[:flux_folder] = ::File.join(Rails.configuration.rncs_sources_path, 'tc', 'flux')
 
         step :fetch_updates
         step :deserialize

--- a/app/concepts/tribunal_commerce/daily_update/operation/fetch_partial_stocks_in_pipe.rb
+++ b/app/concepts/tribunal_commerce/daily_update/operation/fetch_partial_stocks_in_pipe.rb
@@ -4,7 +4,7 @@ module TribunalCommerce
       class FetchPartialStocksInPipe < Trailblazer::Operation
         extend ClassDependencies
 
-        self[:partial_stock_folder] = ::File.join(Rails.configuration.rncs_sources['path'], 'tc', 'stock')
+        self[:partial_stock_folder] = ::File.join(Rails.configuration.rncs_sources_path, 'tc', 'stock')
 
         step :fetch_updates
         step :deserialize

--- a/app/concepts/tribunal_commerce/stock/operation/import.rb
+++ b/app/concepts/tribunal_commerce/stock/operation/import.rb
@@ -5,7 +5,7 @@ module TribunalCommerce
         extend ClassDependencies
         include TrailblazerHelper::DBIndexes
 
-        self[:stocks_folder] = ::File.join(Rails.configuration.rncs_sources['path'], 'tc/stock')
+        self[:stocks_folder] = ::File.join(Rails.configuration.rncs_sources_path, 'tc/stock')
         self[:logger] = Rails.logger
 
         step :log_import_start

--- a/app/concepts/tribunal_instance/daily_update/task/fetch_in_pipe.rb
+++ b/app/concepts/tribunal_instance/daily_update/task/fetch_in_pipe.rb
@@ -4,7 +4,7 @@ module TribunalInstance
       class FetchInPipe < Trailblazer::Operation
         extend ClassDependencies
 
-        self[:flux_folder] = ::File.join(Rails.configuration.rncs_sources['path'], 'titmc', 'flux')
+        self[:flux_folder] = ::File.join(Rails.configuration.rncs_sources_path, 'titmc', 'flux')
 
         step :fetch_updates
         step :deserialize

--- a/app/concepts/tribunal_instance/stock/operation/load.rb
+++ b/app/concepts/tribunal_instance/stock/operation/load.rb
@@ -5,7 +5,7 @@ module TribunalInstance
         extend ClassDependencies
         include TrailblazerHelper::DBIndexes
 
-        self[:stocks_folder] = ::File.join(Rails.configuration.rncs_sources['path'], 'titmc', 'stock')
+        self[:stocks_folder] = ::File.join(Rails.configuration.rncs_sources_path, 'titmc', 'stock')
         self[:stock_class] = StockTribunalInstance
 
         pass ->(ctx, logger:, **) { logger.info 'Checking last TITMC stock...' }

--- a/app/jobs/sync_ftp_job.rb
+++ b/app/jobs/sync_ftp_job.rb
@@ -34,7 +34,7 @@ class SyncFTPJob < ActiveJob::Base
   end
 
   def rncs_dir_prefix
-    Rails.configuration.rncs_sources['path_prefix']
+    Rails.configuration.rncs_sources['local_path_prefix']
   end
 
   def rncs_sources_path

--- a/app/jobs/sync_ftp_job.rb
+++ b/app/jobs/sync_ftp_job.rb
@@ -20,19 +20,17 @@ class SyncFTPJob < ActiveJob::Base
   end
 
   def sync_files
-    _stdout, stderr, status = Open3.capture3 lftp_command
+    _stdout, stderr, status = Open3.capture3 wget_command
     Rails.logger.error "LFTP sync failed with: #{stderr}" unless status.success?
   end
 
-  def lftp_command
-    <<-ENDLFTP
-    lftp -u '#{ftp_login}','#{ftp_password}' -p 21 opendata-rncs.inpi.fr -e '
-      mirror -c -P 2 -F public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month}/ -O #{rncs_source_path}/tc/flux/#{current_year};
-      mirror -c -P 2 -F public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month}/ -O #{rncs_source_path}/tc/flux/#{year_of_previous_month};
-      mirror -c -P 2 -F public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month}/ -O #{rncs_source_path}/tc/stock/#{current_year};
-      mirror -c -P 2 -F public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}/ -O #{rncs_source_path}/tc/stock/#{year_of_previous_month};
-      quit'
-    ENDLFTP
+  def wget_command
+    <<-ENDWGET
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}
+    ENDWGET
   end
 
   def rncs_source_path
@@ -65,14 +63,10 @@ class SyncFTPJob < ActiveJob::Base
 
   def clean_sync_folders
     sync_folders = [
-      "#{rncs_source_path}/tc/flux/#{current_year}/#{current_month}",
-      "#{rncs_source_path}/tc/flux/#{current_year}",
-      "#{rncs_source_path}/tc/flux/#{year_of_previous_month}/#{previous_month}",
-      "#{rncs_source_path}/tc/flux/#{year_of_previous_month}",
-      "#{rncs_source_path}/tc/stock/#{current_year}/#{current_month}",
-      "#{rncs_source_path}/tc/stock/#{current_year}",
-      "#{rncs_source_path}/tc/stock/#{year_of_previous_month}/#{previous_month}",
-      "#{rncs_source_path}/tc/stock/#{year_of_previous_month}",
+      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}",
+      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}",
+      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}",
+      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}",
     ]
 
     sync_folders.each do |dir|

--- a/app/jobs/sync_ftp_job.rb
+++ b/app/jobs/sync_ftp_job.rb
@@ -26,10 +26,10 @@ class SyncFTPJob < ActiveJob::Base
 
   def wget_command
     <<-ENDWGET
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}
     ENDWGET
   end
 

--- a/app/jobs/sync_ftp_job.rb
+++ b/app/jobs/sync_ftp_job.rb
@@ -12,29 +12,33 @@ class SyncFTPJob < ActiveJob::Base
   private
 
   def ensure_permissions_are_correct
-    _stdout, stderr, status = Open3.capture3 "find #{rncs_source_path} -type d -exec chmod 755 {} +"
+    _stdout, stderr, status = Open3.capture3 "find #{rncs_sources_path} -type d -exec chmod 755 {} +"
     Rails.logger.error "Ensure permissions for directories failed with #{stderr}" unless status.success?
 
-    _stdout, stderr, status = Open3.capture3 "find #{rncs_source_path} -type f -exec chmod 644 {} +"
+    _stdout, stderr, status = Open3.capture3 "find #{rncs_sources_path} -type f -exec chmod 644 {} +"
     Rails.logger.error "Ensure permissions for files failed with #{stderr}" unless status.success?
   end
 
   def sync_files
     _stdout, stderr, status = Open3.capture3 wget_command
-    Rails.logger.error "LFTP sync failed with: #{stderr}" unless status.success?
+    Rails.logger.error "WGET sync failed with: #{stderr}" unless status.success?
   end
 
   def wget_command
     <<-ENDWGET
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month};
-    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}/#{previous_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}/#{current_month};
+    wget -r --level=8 -m --reject "index.html" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_dir_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}/#{previous_month}
     ENDWGET
   end
 
-  def rncs_source_path
-    Rails.configuration.rncs_sources['path']
+  def rncs_dir_prefix
+    Rails.configuration.rncs_sources['path_prefix']
+  end
+
+  def rncs_sources_path
+    Rails.configuration.rncs_sources_path
   end
 
   def ftp_login
@@ -63,10 +67,10 @@ class SyncFTPJob < ActiveJob::Base
 
   def clean_sync_folders
     sync_folders = [
-      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{current_year}",
-      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/#{year_of_previous_month}",
-      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{current_year}",
-      "#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/#{year_of_previous_month}",
+      "#{rncs_sources_path}/tc/flux/#{current_year}",
+      "#{rncs_sources_path}/tc/flux/#{year_of_previous_month}",
+      "#{rncs_sources_path}/tc/stock/#{current_year}",
+      "#{rncs_sources_path}/tc/stock/#{year_of_previous_month}",
     ]
 
     sync_folders.each do |dir|

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,6 @@ module RncsWorkerApiEntreprise
     end
 
     config.rncs_sources = config_for(:rncs_sources)
-    config.rncs_sources_path = ::File.join(Rails.configuration.rncs_sources['path_prefix'], Rails.configuration.rncs_sources['ftp_path_prefix'])
+    config.rncs_sources_path = ::File.join(Rails.configuration.rncs_sources['local_path_prefix'], Rails.configuration.rncs_sources['ftp_path_prefix'])
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,5 +57,6 @@ module RncsWorkerApiEntreprise
     end
 
     config.rncs_sources = config_for(:rncs_sources)
+    config.rncs_sources_path = ::File.join(Rails.configuration.rncs_sources['path_prefix'], Rails.configuration.rncs_sources['ftp_path_prefix'])
   end
 end

--- a/setup_rncs_sources.sh
+++ b/setup_rncs_sources.sh
@@ -1,4 +1,4 @@
 echo "test:
-  path_prefix: ./spec/fixtures
+  local_path_prefix: ./spec/fixtures
   ftp_path_prefix: ''
   import_batch_size: 3" > config/rncs_sources.yml

--- a/setup_rncs_sources.sh
+++ b/setup_rncs_sources.sh
@@ -1,3 +1,4 @@
 echo "test:
-  path: ./spec/fixtures
+  path_prefix: ./spec/fixtures
+  ftp_path_prefix: ''
   import_batch_size: 3" > config/rncs_sources.yml

--- a/spec/concepts/tribunal_instance/stock/operation/retrieve_last_stock_spec.rb
+++ b/spec/concepts/tribunal_instance/stock/operation/retrieve_last_stock_spec.rb
@@ -26,7 +26,7 @@ describe TribunalInstance::Stock::Operation::RetrieveLastStock do
   context 'when stocks are found' do
     subject { described_class.call stocks_folder: stock_folder_path, stock_class: DummyStockClass }
 
-    let(:stock_folder_path) { File.join(Rails.configuration.rncs_sources['path'], 'tc', 'stock') }
+    let(:stock_folder_path) { File.join(Rails.configuration.rncs_sources_path, 'tc', 'stock') }
 
     its([:stocks_folder]) { is_expected.to eq stock_folder_path }
     it { is_expected.to be_success }

--- a/spec/jobs/sync_ftp_job_spec.rb
+++ b/spec/jobs/sync_ftp_job_spec.rb
@@ -24,7 +24,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC daily updates for the current month' do
-      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/01"
+      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/01"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(current_month_sync_command))
 
@@ -32,7 +32,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC daily updates for the previous month' do
-      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2018/12"
+      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2018/12"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(previous_month_sync_command))
 
@@ -40,7 +40,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC partial stocks for the current month' do
-      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2019/01"
+      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2019/01"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(current_month_sync_command))
 
@@ -48,7 +48,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC partial stocks for the previous month' do
-      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018/12"
+      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user='#{ftp_login}' --ftp-password='#{ftp_password}' --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018/12"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(previous_month_sync_command))
 

--- a/spec/jobs/sync_ftp_job_spec.rb
+++ b/spec/jobs/sync_ftp_job_spec.rb
@@ -12,7 +12,8 @@ describe SyncFTPJob do
 
   after { Timecop.return }
 
-  let(:rncs_source_path) { Rails.configuration.rncs_sources['path'] }
+  let(:rncs_path_prefix) { Rails.configuration.rncs_sources['path_prefix'] }
+  let(:rncs_sources_path) { Rails.configuration.rncs_sources_path }
   let(:ftp_login) { Rails.application.credentials.ftp_login }
   let(:ftp_password) { Rails.application.credentials.ftp_password }
 
@@ -23,7 +24,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC daily updates for the current month' do
-      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/01"
+      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/01"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(current_month_sync_command))
 
@@ -31,7 +32,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC daily updates for the previous month' do
-      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2018/12"
+      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2018/12"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(previous_month_sync_command))
 
@@ -39,7 +40,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC partial stocks for the current month' do
-      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2019/01"
+      current_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2019/01"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(current_month_sync_command))
 
@@ -47,7 +48,7 @@ describe SyncFTPJob do
     end
 
     it 'syncs TC partial stocks for the previous month' do
-      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_source_path} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018/12"
+      previous_month_sync_command = "wget -r --level=8 -m --reject \"index.html\" -c -N --secure-protocol=auto --no-proxy --ftp-user=#{ftp_login} --ftp-password=#{ftp_password} --directory-prefix=#{rncs_path_prefix} --no-check-certificate ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018/12"
       expect(Open3).to receive(:capture3)
         .with(a_string_including(previous_month_sync_command))
 
@@ -55,8 +56,8 @@ describe SyncFTPJob do
     end
 
     it 'changes file permissions of the files and folders to deploy after sync' do
-      change_dirs_permissions_cmd = "find #{rncs_source_path} -type d -exec chmod 755 {} +"
-      change_files_permissions_cmd = "find #{rncs_source_path} -type f -exec chmod 644 {} +"
+      change_dirs_permissions_cmd = "find #{rncs_sources_path} -type d -exec chmod 755 {} +"
+      change_files_permissions_cmd = "find #{rncs_sources_path} -type f -exec chmod 644 {} +"
       expect(Open3).to receive(:capture3).with(/wget/).ordered
       expect(Open3).to receive(:capture3).with(change_dirs_permissions_cmd).ordered
       expect(Open3).to receive(:capture3).with(change_files_permissions_cmd).ordered
@@ -78,26 +79,26 @@ describe SyncFTPJob do
       # Mock wget system call and manually create targetted folders
       expect(Open3).to receive(:capture3)
         .and_wrap_original do |original_method, *args|
-        FileUtils.mkdir_p("#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018/12")
-        FileUtils.mkdir_p("#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019")
+        FileUtils.mkdir_p("#{rncs_sources_path}/tc/stock/2018/12")
+        FileUtils.mkdir_p("#{rncs_sources_path}/tc/flux/2019")
         ['', '', status_success]
       end
 
       allow_chmod_success
     end
 
-    after { FileUtils.rm_rf("#{rncs_source_path}/opendata-rncs.inpi.fr") }
+    after { FileUtils.remove_dir("#{rncs_sources_path}/tc/stock/2018/12") }
 
     it 'deletes empty year folders' do
       subject
 
-      expect(Dir.exists?("#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019")).to eq(false)
+      expect(Dir.exists?("#{rncs_sources_path}/tc/flux/2019")).to eq(false)
     end
 
     it 'keeps non empty year folders' do
       subject
 
-      expect(Dir.exists?("#{rncs_source_path}/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/stock/2018")).to eq(true)
+      expect(Dir.exists?("#{rncs_sources_path}/tc/stock/2018")).to eq(true)
     end
   end
 
@@ -108,7 +109,7 @@ describe SyncFTPJob do
     end
 
     it 'logs an error' do
-      expect(Rails.logger).to receive(:error).with('LFTP sync failed with: random error')
+      expect(Rails.logger).to receive(:error).with('WGET sync failed with: random error')
       subject
     end
   end


### PR DESCRIPTION
### Contenu de la PR
* Utilisation de *wget* en lieu et place de *lftp* pour les synchronisation quotidiennes avec le FTP de l'INPI
* Changement dans la configuration du path cible des fichiers sources

Concernant le deuxième point, cela est dû au fonctionnement de Wget : lorsque on utilise le mode récursif pour télécharger un dossier distant, on peut lui spécifier un dossier de préfixe dans lequel il va synchroniser le dossier cible en recopiant entièrement l'arborescence du dossier source.

Par exemple, jusqu'ici nous disions à *LFTP* de synchroniser le contenu du dossier source `public/IMR_Donnees_Saisies` dans le dossier `/home/deploy/rncs_data/IMR_Donnees_Saisies` (les dossiers parents que l'on trouve sur le FTP source ne sont pas répliqués ici). Aujourd'hui, avec *Wget*, nous récupérons le dossier du mois en cours présent à `ftps://opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/07` et celui-ci est rangé dans le dossier `/home/deploy/rncs_data/opendata-rncs.inpi.fr/public/IMR_Donnees_Saisies/tc/flux/2019/07`.

### Changement à effectuer dans l'environnement de développement
Je vous invite à faire les changements dans vos fichiers `config/rncs_sources.yml` en accord avec le README mis à jour.