### PR TITLE
Traitement des fichiers CSV avec un parser conforme à la RFC 4180

### DIFF
--- a/app/concepts/tribunal_commerce/helper/file_importer.rb
+++ b/app/concepts/tribunal_commerce/helper/file_importer.rb
@@ -4,7 +4,7 @@ module TribunalCommerce
       attr_reader :file_reader_class, :logger
 
       # TODO here container would be great because it could provide the right logger
-      def initialize(logger, file_reader_class = CSVReader)
+      def initialize(logger, file_reader_class = StandardCSVReader)
         @file_reader_class = file_reader_class
         @logger = logger
       end

--- a/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
+++ b/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
@@ -65,6 +65,7 @@ module TribunalCommerce
         {
           col_sep: ';',
           headers: true,
+          converters: [strip_data],
           header_converters: [harmonize_headers]
         }
       end
@@ -83,6 +84,10 @@ module TribunalCommerce
             .then { |it| it.to_sym }
             .then { |it| map_header(it) }
         end
+      end
+
+      def strip_data
+        ->(value) { value.strip unless value.nil? }
       end
 
       def map_header(h)

--- a/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
+++ b/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
@@ -42,6 +42,7 @@ module TribunalCommerce
         Proc.new do |headers|
           headers.map do |h|
             h.then { |it| it.downcase }
+             .then { |it| it.strip }
              .then { |it| it.gsub(/\./, '') }
              .then { |it| it.gsub(/\s|-/, '_') }
              .then { |it| I18n.transliterate(it) }

--- a/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
+++ b/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
@@ -7,6 +7,7 @@ module TribunalCommerce
         @file = file
         @options = default_options
         @headers_mapping = mapping
+        @keep_nil = keep_nil
       end
 
       def line_processing
@@ -38,6 +39,7 @@ module TribunalCommerce
       def handle_csv_by_batch(csv, batch_size)
         csv.each_slice(batch_size) do |array_of_csv_row|
           array_of_hash = from_csv_row_class_to_hash(array_of_csv_row)
+          remove_nil_values(array_of_hash) unless keep_nil?
           yield(array_of_hash)
         end
       end
@@ -51,6 +53,12 @@ module TribunalCommerce
 
       def discard_values_from_header_mapped_to_nil(csv_row)
         csv_row.delete_if { |k, v| k.nil? }
+      end
+
+      def remove_nil_values(array_of_hash)
+        array_of_hash.map! do |row_hash|
+          row_hash.reject { |_, v| v.nil? }
+        end
       end
 
       def default_options
@@ -79,6 +87,10 @@ module TribunalCommerce
 
       def map_header(h)
         headers_mapping.has_key?(h) ? headers_mapping[h] : h
+      end
+
+      def keep_nil?
+        @keep_nil
       end
     end
   end

--- a/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
+++ b/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
@@ -38,13 +38,13 @@ module TribunalCommerce
 
       def handle_csv_by_batch(csv, batch_size)
         csv.each_slice(batch_size) do |array_of_csv_row|
-          array_of_hash = from_csv_row_class_to_hash(array_of_csv_row)
+          array_of_hash = convert_from_csv_row_class_to_hash(array_of_csv_row)
           remove_nil_values(array_of_hash) unless keep_nil?
           yield(array_of_hash)
         end
       end
 
-      def from_csv_row_class_to_hash(csv)
+      def convert_from_csv_row_class_to_hash(csv)
         csv.map do |csv_row|
           discard_values_from_header_mapped_to_nil(csv_row)
           csv_row.to_hash

--- a/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
+++ b/app/concepts/tribunal_commerce/helper/standard_csv_reader.rb
@@ -1,0 +1,54 @@
+module TribunalCommerce
+  module Helper
+    class StandardCSVReader
+      attr_reader :file, :options
+
+      def initialize(file, mapping, keep_nil:false, **)
+        @file = file
+        @options = default_options
+        add_mapping_to_options(mapping)
+      end
+
+      def line_processing
+        proceed do |chunk|
+          chunk.each { |row| yield(row) }
+        end
+      end
+
+      def bulk_processing
+        proceed { |batch| yield(batch) }
+      end
+
+      def proceed
+        ::File.open(file, 'r:bom|utf-8') do |f|
+          SmarterCSV.process(f, options) { |batch| yield(batch) }
+        end
+      end
+
+      def default_options
+        {
+          col_sep: ';',
+          chunk_size: Rails.configuration.rncs_sources['import_batch_size'],
+          header_transformations: [:none, harmonize_headers],
+          hash_transformations: [:none]
+        }
+      end
+
+      def add_mapping_to_options(mapping)
+        @options[:header_transformations].push({ key_mapping: mapping })
+      end
+
+      def harmonize_headers
+        Proc.new do |headers|
+          headers.map do |h|
+            h.then { |it| it.downcase }
+             .then { |it| it.gsub(/\./, '') }
+             .then { |it| it.gsub(/\s|-/, '_') }
+             .then { |it| I18n.transliterate(it) }
+             .then { |it| it.to_sym }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
+++ b/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
@@ -108,7 +108,7 @@ describe TribunalCommerce::Helper::StandardCSVReader do
       it 'discards values for headers mapped to nil' do
         example_mapping[:much_value] = nil
 
-        expect(parsed_csv).to all(exclude(:much_value, nil))
+        expect(parsed_csv).to all(exclude(:much_value))
       end
 
       it 'strips headers surrounding spaces' do

--- a/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
+++ b/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
@@ -89,7 +89,7 @@ describe TribunalCommerce::Helper::StandardCSVReader do
     before do
       file = File.new(example_file, 'w+')
       content = <<-CSV
-      Very data;Much Value;Vérï acçents;l.o.l;   Space;strip
+      Very data;Much Value;Vérï acçents;l.o.l  ;   Space;strip
       ;hello;bondour;coucou;espace;"  tease     "
       wow;hey;yo;le nouveau son;ciel;strip col
       much value;012;test;'';universe;dunno
@@ -116,7 +116,7 @@ describe TribunalCommerce::Helper::StandardCSVReader do
       end
 
       it 'strips headers surrounding spaces' do
-        expect(parsed_csv).to all(include(:space))
+        expect(parsed_csv).to all(include(:space, :lol))
       end
 
       it 'symbolizes headers' do

--- a/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
+++ b/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
@@ -1,0 +1,136 @@
+require 'rails_helper'
+
+RSpec::Matchers.define_negated_matcher :exclude, :include
+
+describe TribunalCommerce::Helper::StandardCSVReader do
+  let(:example_file) { Rails.root.join('spec/fixtures/csv_reader_spec.csv') }
+
+  shared_context 'simple csv example' do
+    let(:example_mapping) do
+      {
+        'Data A' => :data_a,
+        'Data B' => :data_b,
+      }
+    end
+
+    before do
+      file = File.new(example_file, 'w+')
+      content = <<-CSV
+      Data A;Data B
+      A1;B1
+      A2;B2
+      A3;B3
+      A4;B4
+      A5;B5
+      CSV
+      file.write(content.unindent)
+      file.close
+    end
+
+    after { FileUtils.rm_rf(example_file) }
+  end
+
+  describe '#bulk_processing' do
+    include_context 'simple csv example'
+
+    subject { described_class.new(example_file) }
+
+    specify 'batch size is configured in config/rncs_sources.yml' do
+      options = subject.instance_variable_get(:@options)
+
+      expect(options[:chunk_size])
+        .to eq(Rails.configuration.rncs_sources['import_batch_size'])
+    end
+
+    # :chunk_size is set to 3 in test environment
+    it 'yields chunks of lines' do
+      expect { |block_checker| subject.bulk_processing(&block_checker) }
+        .to yield_successive_args(
+          [
+            { data_a: 'A1', data_b: 'B1' },
+            { data_a: 'A2', data_b: 'B2' },
+            { data_a: 'A3', data_b: 'B3' }
+          ],
+          [
+            { data_a: 'A4', data_b: 'B4' },
+            { data_a: 'A5', data_b: 'B5' }
+          ])
+    end
+
+    it 'keeps nil values in the target hash'
+  end
+
+  describe '#line_processing' do
+    include_context 'simple csv example'
+
+    subject { described_class.new(example_file) }
+
+    it 'yields lines one by one' do
+      expect { |block_checker| subject.line_processing(&block_checker) }
+        .to yield_successive_args(
+          { data_a: 'A1', data_b: 'B1' },
+          { data_a: 'A2', data_b: 'B2' },
+          { data_a: 'A3', data_b: 'B3' },
+          { data_a: 'A4', data_b: 'B4' },
+          { data_a: 'A5', data_b: 'B5' },
+      )
+    end
+
+    it 'ignores nil values in the target hash'
+  end
+
+  describe 'CSV parsing behaviour' do
+    let(:example_mapping) do
+      {
+        'Very data' => :very_data,
+        'Much Value' => :much_value,
+      }
+    end
+
+    before do
+      file = File.new(example_file, 'w+')
+      content = <<-CSV
+      Very data;Much Value;Vérï acçents;l.o.l
+      ;hello;bondour;coucou
+      wow;hey;yo;le nouveau son
+      much value;012;test;''
+      CSV
+      file.write(content.unindent)
+      file.close
+    end
+
+    after { FileUtils.rm_rf(example_file) }
+
+    it 'transforms header according to the headers mapping dictionary' do
+      expect(parsed_csv).to all(include(:very_data, :much_value))
+    end
+
+    it 'discards values for headers mapped to nil' do
+      example_mapping[:much_value] = nil
+
+      expect(parsed_csv).to all(include(:very_data))
+      expect(parsed_csv).to all(exclude(:much_value))
+    end
+
+    it 'symbolizes headers' do
+      example_mapping.delete('Much Value')
+
+      expect(parsed_csv).to all(include(:very_data, :much_value))
+    end
+
+    it 'transliterates headers name' do
+      expect(parsed_csv).to all(include(:veri_accents))
+    end
+
+    it 'removes dot characters from headers' do
+      expect(parsed_csv).to all(include(:lol))
+    end
+
+    def parsed_csv
+      reader = described_class.new(example_file, example_mapping)
+      csv = []
+      reader.proceed { |batch| csv << batch }
+      csv.flatten
+    end
+  end
+end

--- a/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
+++ b/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
@@ -42,7 +42,7 @@ describe TribunalCommerce::Helper::StandardCSVReader do
     end
 
     # :chunk_size is set to 3 in test environment
-    it 'yields chunks of lines' do
+    it 'yields chunks of lines and keeps nil values' do
       expect { |block_checker| subject.bulk_processing(&block_checker) }
         .to yield_successive_args(
           [
@@ -55,8 +55,6 @@ describe TribunalCommerce::Helper::StandardCSVReader do
             { data_a: 'A5', data_b: 'B5' }
           ])
     end
-
-    it 'keeps nil values in the target hash' # indirectly tested in the previous spec
   end
 
   describe '#line_processing' do
@@ -64,7 +62,7 @@ describe TribunalCommerce::Helper::StandardCSVReader do
 
     subject { described_class.new(example_file, example_mapping) }
 
-    it 'yields lines one by one' do
+    it 'yields lines one by one and discards nil values' do
       expect { |block_checker| subject.line_processing(&block_checker) }
         .to yield_successive_args(
           { data_a: 'A1', data_b: 'B1' },
@@ -74,8 +72,6 @@ describe TribunalCommerce::Helper::StandardCSVReader do
           { data_a: 'A5', data_b: 'B5' },
       )
     end
-
-    it 'discards nil values in the result hash' # indirectly tested in the previous spec
   end
 
   describe 'CSV parsing behaviour' do

--- a/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
+++ b/spec/concepts/tribunal_commerce/helper/standard_csv_reader_spec.rb
@@ -90,10 +90,10 @@ describe TribunalCommerce::Helper::StandardCSVReader do
     before do
       file = File.new(example_file, 'w+')
       content = <<-CSV
-      Very data;Much Value;Vérï acçents;l.o.l
-      ;hello;bondour;coucou
-      wow;hey;yo;le nouveau son
-      much value;012;test;''
+      Very data;Much Value;Vérï acçents;l.o.l;   Space
+      ;hello;bondour;coucou;espace
+      wow;hey;yo;le nouveau son;ciel
+      much value;012;test;'';universe
       CSV
       file.write(content.unindent)
       file.close
@@ -110,6 +110,10 @@ describe TribunalCommerce::Helper::StandardCSVReader do
 
       expect(parsed_csv).to all(include(:very_data))
       expect(parsed_csv).to all(exclude(:much_value))
+    end
+
+    it 'strips headers surrounding spaces' do
+      expect(parsed_csv).to all(include(:space))
     end
 
     it 'symbolizes headers' do

--- a/spec/support/shared_examples/file_import.rb
+++ b/spec/support/shared_examples/file_import.rb
@@ -1,13 +1,13 @@
 shared_examples 'bulk_import' do |import_method, imported_model, file_mapping|
   let(:file_path) { 'very path' }
   let(:logger) { instance_spy(Logger) }
-  let(:csv_reader) { instance_spy(TribunalCommerce::Helper::CSVReader) }
+  let(:csv_reader) { instance_spy(TribunalCommerce::Helper::StandardCSVReader) }
 
   # Mocking the CSVReader here for unit tests
   # This callback also ensure the import method call will initialize the
   # CSVReader correctly (with the right :keep_nil option)
   before do
-    allow(TribunalCommerce::Helper::CSVReader)
+    allow(TribunalCommerce::Helper::StandardCSVReader)
       .to receive(:new)
       .with(file_path, file_mapping, keep_nil: true)
       .and_return(csv_reader)
@@ -60,13 +60,13 @@ end
 shared_examples 'import_line_by_line' do |import_method, line_processor, file_mapping|
   let(:file_path) { 'im a path lol' }
   let(:logger) { instance_spy(Logger) }
-  let(:csv_reader) { instance_spy(TribunalCommerce::Helper::CSVReader) }
+  let(:csv_reader) { instance_spy(TribunalCommerce::Helper::StandardCSVReader) }
 
   # Mocking the CSVReader here for unit tests
   # This callback also ensure the import method call will initialize the
   # CSVReader correctly (with the right :keep_nil option)
   before do
-    allow(TribunalCommerce::Helper::CSVReader)
+    allow(TribunalCommerce::Helper::StandardCSVReader)
       .to receive(:new)
       .with(file_path, file_mapping, keep_nil: false)
       .and_return(csv_reader)


### PR DESCRIPTION
### Contenu de la PR 
Utilisation d'un parser CSV conforme à la RFC. Cela permet d'éviter des erreurs lors de l'import de fichiers CSV valides dues à l'implémentation "maison" du premier parser CSV. Les traitements sur les headers à des fins d'uniformisation ont été reportés dans l'implémentation du nouveau parser CSV.

Cela implique un traitement préalable sur les fichiers CSV non valides qui ont été diffusés sur le FTP de l'INPI au tout début. Ces scripts de nettoyage seront rajoutés à ce répertoire de source dans une autre PR.

### Comment faire la review 
Au choix : pas très long de faire la review globalement, commits par commits pour voir l'implémentation des règles (sur les headers notamment).

Fix #125 