### PR TITLE
Immatriculation principale

### DIFF
--- a/app/concepts/dossier_entreprise/operation/fetch_immatriculation_principale.rb
+++ b/app/concepts/dossier_entreprise/operation/fetch_immatriculation_principale.rb
@@ -1,0 +1,50 @@
+class DossierEntreprise
+  module Operation
+    class FetchImmatriculationPrincipale < Trailblazer::Operation
+      step :any_immatriculations_principales?
+      failure :any_immatriculations_secondaires?, Output(:success) => Track(:immatriculation_secondaire)
+      failure :log_not_registered_to_rncs, Output(:failure) => 'End.failure'
+
+      step :uniq?, Output(:success) => 'End.success'
+      failure :none_date_immatriculation_nil?, Output(:success) => Track(:success)
+      failure :log_failed_to_find_valid_immatriculation, Output(:failure) => 'End.failure'
+      step :choose_latest_immatriculation_principale
+
+      failure :log_registered_but_no_immatriculation_principale_found, magnetic_to: [:immatriculation_secondaire]
+
+      def any_immatriculations_principales?(ctx, siren:, **)
+        ctx[:dossiers] = DossierEntreprise.where(siren: siren, type_inscription: 'P')
+        ctx[:dossiers].any?
+      end
+
+      def any_immatriculations_secondaires?(ctx, siren:, **)
+        ctx[:dossiers] = DossierEntreprise.where(siren: siren, type_inscription: 'S')
+        ctx[:dossiers].any?
+      end
+
+      def uniq?(ctx, dossiers:, **)
+        ctx[:dossier_principal] = dossiers.first if dossiers.size == 1
+      end
+
+      def none_date_immatriculation_nil?(_, dossiers:, **)
+        dossiers.none? { |immat| immat.date_immatriculation.nil? }
+      end
+
+      def choose_latest_immatriculation_principale(ctx, dossiers:, **)
+        ctx[:dossier_principal] = dossiers.max_by { |immat| Date.parse(immat.date_immatriculation) }
+      end
+
+      def log_failed_to_find_valid_immatriculation(ctx, siren:, **)
+        ctx[:error] = "Impossible de constituer la fiche pour le SIREN #{siren}."
+      end
+
+      def log_not_registered_to_rncs(ctx, siren:, **)
+        ctx[:error] = "Le SIREN #{siren} n'est pas inscrit au RNCS."
+      end
+
+      def log_registered_but_no_immatriculation_principale_found(ctx, siren:,**)
+        ctx[:error] = "Immatriculation principale non trouvée pour le siren #{siren}."
+      end
+    end
+  end
+end

--- a/app/concepts/dossier_entreprise/operation/fetch_immatriculation_principale.rb
+++ b/app/concepts/dossier_entreprise/operation/fetch_immatriculation_principale.rb
@@ -2,11 +2,11 @@ class DossierEntreprise
   module Operation
     class FetchImmatriculationPrincipale < Trailblazer::Operation
       step :any_immatriculation?
-      failure :log_no_rncs_immatriculation, Output(:success) => 'End.failure'
+      failure :log_no_rncs_immatriculation, fail_fast: true
       step :any_immatriculation_principale?
-      failure :log_immat_secondaire_only, Output(:success) => 'End.failure'
+      failure :log_immat_secondaire_only, fail_fast: true
       step :possible_to_identify_immat_principale?
-      failure :log_cannot_identify_latest_immat, Output(:success) => 'End.failure'
+      failure :log_cannot_identify_latest_immat, fail_fast: true
       step :return_only_or_latest_immat_principale
 
       def any_immatriculation?(ctx, siren:, **)
@@ -21,7 +21,7 @@ class DossierEntreprise
 
       def possible_to_identify_immat_principale?(_, immat_principales:, **)
         one_immat_only = immat_principales.count == 1
-        all_date_immat_filled = immat_principales.all? { |d| !d.date_immatriculation.nil? }
+        all_date_immat_filled = immat_principales.all? { |d| !d.date_immatriculation.blank? }
         one_immat_only || all_date_immat_filled
       end
 

--- a/app/concepts/entreprise/operation/identity.rb
+++ b/app/concepts/entreprise/operation/identity.rb
@@ -5,7 +5,7 @@ module Entreprise
         fail :empty_database, fail_fast: true
       step :verify_siren
         fail :invalid_siren, fail_fast: true
-      step Nested(DossierEntreprise::Operation::FetchImmatriculationPrincipale)
+      step Nested(DossierEntreprise::Operation::FetchImmatriculationPrincipale), Output(:fail_fast) => Track(:failure)
         fail :no_immatriculation_principale, fail_fast: true
       step :fetch_etablissement_principal
         fail :no_etablissement_principal

--- a/app/concepts/entreprise/operation/identity.rb
+++ b/app/concepts/entreprise/operation/identity.rb
@@ -5,7 +5,7 @@ module Entreprise
         fail :empty_database, fail_fast: true
       step :verify_siren
         fail :invalid_siren, fail_fast: true
-      step :fetch_immatriculation_principale
+      step Nested(DossierEntreprise::Operation::FetchImmatriculationPrincipale)
         fail :no_immatriculation_principale, fail_fast: true
       step :fetch_etablissement_principal
         fail :no_etablissement_principal
@@ -20,12 +20,8 @@ module Entreprise
         ctx[:http_error] = { code: 422, message: 'Le numéro siren en paramètre est mal formaté.' }
       end
 
-      def fetch_immatriculation_principale(ctx, siren:, **)
-        ctx[:dossier_principal] = DossierEntreprise.immatriculation_principale(siren)
-      end
-
-      def no_immatriculation_principale(ctx, siren:, **)
-        ctx[:http_error] = { code: 404, message: "Immatriculation principale non trouvée pour le siren #{siren}." }
+      def no_immatriculation_principale(ctx, siren:, error:, **)
+        ctx[:http_error] = { code: 404, message: error }
       end
 
       def fetch_etablissement_principal(ctx, dossier_principal:, **)

--- a/app/models/dossier_entreprise.rb
+++ b/app/models/dossier_entreprise.rb
@@ -13,15 +13,6 @@ class DossierEntreprise < ApplicationRecord
     dependent: :destroy,
     class_name: 'TribunalInstance::Entreprise'
 
-
-  # TODO Move this into a Trailblazer Task for the Entreprise concept
-  def self.immatriculation_principale(siren)
-    all_immat = self.where(siren: siren, type_inscription: 'P')
-    return all_immat.first if all_immat.size < 2
-    return nil if all_immat.any? { |immat| immat.date_immatriculation.nil? }
-    all_immat.max_by { |immat| Date.parse(immat.date_immatriculation) }
-  end
-
   # this will not warn about multiple SIE/SEP on this dossier / siren
   def siege_social
     @siege_social ||= etablissements.find_by(type_etablissement: 'SIE') || etablissements.find_by(type_etablissement: 'SEP')

--- a/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
+++ b/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
@@ -7,7 +7,7 @@ describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
   context 'when only one immatriculation principale found' do
     let!(:dossier) { create(:dossier_entreprise, siren: siren) }
 
-    its(:success?) { is_expected.to be_truthy }
+    its(:success?) { is_expected.to eq(true) }
     its([:dossier_principal]) { is_expected.to eq dossier }
     its([:error]) { is_expected.to be_nil }
   end
@@ -16,15 +16,15 @@ describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
     context 'but has some immatriculation secondaire' do
       let!(:dossier) { create(:dossier_entreprise, siren: siren, type_inscription: 'S') }
 
-      its(:success?) { is_expected.to be_falsey }
+      its(:success?) { is_expected.to eq(false) }
       its([:dossier_principal]) { is_expected.to be_nil }
       its([:error]) { is_expected.to eq "Immatriculation principale non trouvée pour le siren #{siren}." }
     end
 
     context 'and has no immatriculation secondaire' do
-      its(:success?) { is_expected.to be_falsey }
+      its(:success?) { is_expected.to eq(false) }
       its([:dossier_principal]) { is_expected.to be_nil }
-      its([:error]) { is_expected.to eq "Le SIREN #{siren} n'est pas inscrit au RNCS." }
+      its([:error]) { is_expected.to eq "Aucune immatriculation trouvée pour le siren #{siren}" }
     end
   end
 
@@ -34,7 +34,7 @@ describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
     describe 'returns the latest' do
       let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: '1999-12-31') }
 
-      its(:success?) { is_expected.to be_truthy }
+      its(:success?) { is_expected.to eq(true) }
       its([:dossier_principal]) { is_expected.to eq new_dossier }
       its([:error]) { is_expected.to be_nil }
     end
@@ -42,7 +42,7 @@ describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
     describe 'fails when at least one nil date_immatriculation' do
       let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: nil) }
 
-      its(:success?) { is_expected.to be_falsey }
+      its(:success?) { is_expected.to eq(false) }
       its([:dossier_principal]) { is_expected.to be_nil }
       its([:error]) { is_expected.to eq "Impossible de constituer la fiche pour le SIREN #{siren}." }
     end

--- a/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
+++ b/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
+  subject { described_class.call(siren: siren) }
+  let(:siren) { '123456789' }
+
+  context 'when only one immatriculation principale found' do
+    let!(:dossier) { create(:dossier_entreprise, siren: siren) }
+
+    its(:success?) { is_expected.to be_truthy }
+    its([:dossier_principal]) { is_expected.to eq dossier }
+    its([:error]) { is_expected.to be_nil }
+  end
+
+  context 'when no immatriculation principale found' do
+    context 'but has some immatriculation secondaire' do
+      let!(:dossier) { create(:dossier_entreprise, siren: siren, type_inscription: 'S') }
+
+      its(:success?) { is_expected.to be_falsey }
+      its([:dossier_principal]) { is_expected.to be_nil }
+      its([:error]) { is_expected.to eq "Immatriculation principale non trouvée pour le siren #{siren}." }
+    end
+
+    context 'and has no immatriculation secondaire' do
+      its(:success?) { is_expected.to be_falsey }
+      its([:dossier_principal]) { is_expected.to be_nil }
+      its([:error]) { is_expected.to eq "Le SIREN #{siren} n'est pas inscrit au RNCS." }
+    end
+  end
+
+  context 'when mutliple immatriculation principale found' do
+    let!(:new_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: '2000-01-01') }
+
+    describe 'returns the latest' do
+      let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: '1999-12-31') }
+
+      its(:success?) { is_expected.to be_truthy }
+      its([:dossier_principal]) { is_expected.to eq new_dossier }
+      its([:error]) { is_expected.to be_nil }
+    end
+
+    describe 'fails when at least one nil date_immatriculation' do
+      let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: nil) }
+
+      its(:success?) { is_expected.to be_falsey }
+      its([:dossier_principal]) { is_expected.to be_nil }
+      its([:error]) { is_expected.to eq "Impossible de constituer la fiche pour le SIREN #{siren}." }
+    end
+  end
+end

--- a/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
+++ b/spec/concepts/dossier_entreprise/operation/fetch_immatriculation_principale_spec.rb
@@ -39,8 +39,8 @@ describe DossierEntreprise::Operation::FetchImmatriculationPrincipale do
       its([:error]) { is_expected.to be_nil }
     end
 
-    describe 'fails when at least one nil date_immatriculation' do
-      let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: nil) }
+    describe 'fails when at least one nil/blank date_immatriculation' do
+      let!(:old_dossier) { create(:dossier_entreprise, siren: siren, date_immatriculation: '') }
 
       its(:success?) { is_expected.to eq(false) }
       its([:dossier_principal]) { is_expected.to be_nil }

--- a/spec/concepts/entreprise/operation/identity_spec.rb
+++ b/spec/concepts/entreprise/operation/identity_spec.rb
@@ -32,7 +32,7 @@ describe Entreprise::Operation::Identity do
       end
 
       it 'returns an error message' do
-        expect(http_error[:message]).to match("Le SIREN #{siren} n'est pas inscrit au RNCS")
+        expect(http_error[:message]).to match("Aucune immatriculation trouvée pour le siren #{siren}")
       end
     end
 

--- a/spec/concepts/entreprise/operation/identity_spec.rb
+++ b/spec/concepts/entreprise/operation/identity_spec.rb
@@ -25,12 +25,6 @@ describe Entreprise::Operation::Identity do
     context 'when no immatriculation principale is found' do
       let(:siren) { valid_siren }
 
-      before do
-        allow(DossierEntreprise).to receive(:immatriculation_principale)
-          .with(siren)
-          .and_return(nil)
-      end
-
       it { is_expected.to be_failure }
 
       it 'returns a 404 HTTP code' do
@@ -38,19 +32,13 @@ describe Entreprise::Operation::Identity do
       end
 
       it 'returns an error message' do
-        expect(http_error[:message]).to match("Immatriculation principale non trouvée pour le siren #{siren}.")
+        expect(http_error[:message]).to match("Le SIREN #{siren} n'est pas inscrit au RNCS")
       end
     end
 
     context 'when the immatriculation principale is found' do
       let(:siren) { valid_siren }
       let!(:dossier) { create(:dossier_entreprise, code_greffe: 'code_test', numero_gestion: 'numero_test', type_inscription: 'P', siren: siren) }
-
-      before do
-        allow(DossierEntreprise).to receive(:immatriculation_principale)
-          .with(siren)
-          .and_return(dossier)
-      end
 
       context 'when an etablissement principal is found in this dossier' do
         before { create(:etablissement_principal, dossier_entreprise: dossier, enseigne: 'do not forget me') }

--- a/spec/models/dossier_entreprise_spec.rb
+++ b/spec/models/dossier_entreprise_spec.rb
@@ -32,41 +32,6 @@ describe DossierEntreprise do
 
   let(:siren) { '123456789' }
 
-  describe '.immatriculation_principale' do
-    let(:siren) { '123456789' }
-
-    subject { described_class.immatriculation_principale(siren) }
-
-    context 'with a single or zero immatriculation principale found in db' do
-      it 'returns nil if none are found' do
-        create(:dossier_entreprise, siren: siren, type_inscription: 'S')
-
-        expect(subject).to be_nil
-      end
-
-      it 'returns the only existing one if any' do
-        immat_pri = create(:dossier_entreprise, siren: siren, type_inscription: 'P')
-
-        expect(subject).to eq(immat_pri)
-      end
-    end
-
-    context 'with multiple immatriculations principales found in db' do
-      let!(:old_immat) { create(:dossier_entreprise, siren: siren, type_inscription: 'P', date_immatriculation: '2018-01-01') }
-      let!(:latest_immat) { create(:dossier_entreprise, siren: siren, type_inscription: 'P', date_immatriculation: '2019-01-01') }
-
-      it 'returns the latest' do
-        expect(subject).to eq(latest_immat)
-      end
-
-      it 'returns nil if :date_immatriculation is not filled for at least one' do
-        old_immat.update(date_immatriculation: nil)
-
-        expect(subject).to be_nil
-      end
-    end
-  end
-
   # TODO Refactor for better behaviour description
   # describe wich etablissement the methods siege_social and
   # etablissement_principal return in the various situations

--- a/spec/support/shared_examples/controller.rb
+++ b/spec/support/shared_examples/controller.rb
@@ -25,7 +25,7 @@ shared_examples 'handling siren errors' do
     it 'returns 404 with error message' do
       json = JSON.parse response.body
 
-      expect(json).to include_json(error: "Immatriculation principale non trouvée pour le siren #{siren}.")
+      expect(json).to include_json(error: "Le SIREN #{siren} n'est pas inscrit au RNCS.")
     end
   end
 end

--- a/spec/support/shared_examples/controller.rb
+++ b/spec/support/shared_examples/controller.rb
@@ -25,7 +25,7 @@ shared_examples 'handling siren errors' do
     it 'returns 404 with error message' do
       json = JSON.parse response.body
 
-      expect(json).to include_json(error: "Le SIREN #{siren} n'est pas inscrit au RNCS.")
+      expect(json).to include_json(error: "Aucune immatriculation trouvée pour le siren #{siren}")
     end
   end
 end


### PR DESCRIPTION
Passage de 1 à 3 messages d'erreurs : 
- aucune immatriculation trouvée
- aucune immatriculation principale trouvée
- erreur dans l'immatriculation principale

Je ne suis pas super fan de l'opération ; c'est pas très lisible car il y a 5 "sorties" possibles (le cas idéal, le cas où on prend l'immatriculation la plus récente et les 3 messages d'erreurs).
On peut peut-être faire mieux avec des opérations nestées mais j'aime bien l'idée d'avoir tout au même endroit.