### PR TITLE
Ignorer les données associées à des dossiers inconnus

### DIFF
--- a/app/concepts/etablissement/operation/create.rb
+++ b/app/concepts/etablissement/operation/create.rb
@@ -2,7 +2,7 @@ class Etablissement
   module Operation
     class Create < Trailblazer::Operation
       step :find_dossier_entreprise
-        fail :dossier_not_found
+      fail :dossier_not_found, Output(:success) => 'End.success'
       step :save_etablissement
 
 
@@ -18,7 +18,7 @@ class Etablissement
       end
 
       def dossier_not_found(ctx, data:, **)
-        ctx[:error] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
       end
     end
   end

--- a/app/concepts/etablissement/operation/create.rb
+++ b/app/concepts/etablissement/operation/create.rb
@@ -18,7 +18,7 @@ class Etablissement
       end
 
       def dossier_not_found(ctx, data:, **)
-        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The line is ignored and not imported..."
       end
     end
   end

--- a/app/concepts/etablissement/operation/nouveau_modifie.rb
+++ b/app/concepts/etablissement/operation/nouveau_modifie.rb
@@ -33,7 +33,7 @@ class Etablissement
       end
 
       def warn_dossier_not_found(ctx, data:, **)
-        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The etablissement (id_etablissement: #{data[:id_etablissement]}) is not imported."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The line is ignored and not imported..."
       end
     end
   end

--- a/app/concepts/observation/operation/update_or_create.rb
+++ b/app/concepts/observation/operation/update_or_create.rb
@@ -36,7 +36,7 @@ class Observation
       end
 
       def dossier_not_found(ctx, data:, **)
-        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The observation with ID: #{data[:id_observation]} is not imported."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The line is ignored and not imported..."
       end
     end
   end

--- a/app/concepts/representant/operation/create.rb
+++ b/app/concepts/representant/operation/create.rb
@@ -2,7 +2,7 @@ class Representant
   module Operation
     class Create < Trailblazer::Operation
       step :find_dossier_entreprise
-        fail :dossier_not_found
+      fail :dossier_not_found, Output(:success) => 'End.success'
       step :save_representant
 
 
@@ -18,7 +18,7 @@ class Representant
       end
 
       def dossier_not_found(ctx, data:, **)
-        ctx[:error] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
       end
     end
   end

--- a/app/concepts/representant/operation/create.rb
+++ b/app/concepts/representant/operation/create.rb
@@ -18,7 +18,7 @@ class Representant
       end
 
       def dossier_not_found(ctx, data:, **)
-        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. Aborting..."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The line is ignored and not imported..."
       end
     end
   end

--- a/app/concepts/representant/operation/nouveau_modifie.rb
+++ b/app/concepts/representant/operation/nouveau_modifie.rb
@@ -36,7 +36,7 @@ class Representant
       end
 
       def warn_dossier_not_found(ctx, data:, **)
-        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The representant (id_representant: #{data[:id_representant]}, qualite: #{data[:qualite]}) is not imported."
+        ctx[:warning] = "The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The line is ignored and not imported..."
       end
     end
   end

--- a/spec/concepts/etablissement/operation/nouveau_modifie_spec.rb
+++ b/spec/concepts/etablissement/operation/nouveau_modifie_spec.rb
@@ -57,14 +57,7 @@ describe Etablissement::Operation::NouveauModifie do
     end
   end
 
-  # TODO https://github.com/etalab/rncs_worker_api_entreprise/issues/39
   context 'when the related dossier is not found' do
-    it 'returns a warning message' do
-      warning_msg = subject[:warning]
-
-      expect(warning_msg).to eq("The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The etablissement (id_etablissement: #{data[:id_etablissement]}) is not imported.")
-    end
-
-    it { is_expected.to be_success }
+    it_behaves_like 'related dossier not found'
   end
 end

--- a/spec/concepts/etablissement/operation/nouveau_modifie_spec.rb
+++ b/spec/concepts/etablissement/operation/nouveau_modifie_spec.rb
@@ -56,7 +56,7 @@ describe Etablissement::Operation::NouveauModifie do
       it { is_expected.to be_success }
     end
   end
-  #
+
   # TODO https://github.com/etalab/rncs_worker_api_entreprise/issues/39
   context 'when the related dossier is not found' do
     it 'returns a warning message' do

--- a/spec/concepts/observation/operation/update_or_create_spec.rb
+++ b/spec/concepts/observation/operation/update_or_create_spec.rb
@@ -66,12 +66,6 @@ describe Observation::Operation::UpdateOrCreate do
 
   # TODO https://github.com/etalab/rncs_worker_api_entreprise/issues/35
   context 'when associated dossier entreprise is not found' do
-    it 'returns a warning message' do
-      warning_msg = subject[:warning]
-
-      expect(warning_msg).to eq("The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The observation with ID: #{data[:id_observation]} is not imported.")
-    end
-
-    it { is_expected.to be_success }
+    it_behaves_like 'related dossier not found'
   end
 end

--- a/spec/concepts/personne_morale/operation/update_spec.rb
+++ b/spec/concepts/personne_morale/operation/update_spec.rb
@@ -15,7 +15,7 @@ describe PersonneMorale::Operation::Update do
   subject { described_class.call(data: data) }
 
   context 'when the dossier is not found' do
-    it_behaves_like 'related dossier not found'
+    it_behaves_like 'related dossier not found (for PM and PP)'
   end
 
   context 'when the dossier is found' do

--- a/spec/concepts/personne_physique/operation/update_spec.rb
+++ b/spec/concepts/personne_physique/operation/update_spec.rb
@@ -14,7 +14,7 @@ describe PersonnePhysique::Operation::Update do
   subject { described_class.call(data: data) }
 
   context 'when the dossier is not found' do
-    it_behaves_like 'related dossier not found'
+    it_behaves_like 'related dossier not found (for PM and PP)'
   end
 
   context 'when the dossier is found' do

--- a/spec/concepts/representant/operation/nouveau_modifie_spec.rb
+++ b/spec/concepts/representant/operation/nouveau_modifie_spec.rb
@@ -60,14 +60,7 @@ describe Representant::Operation::NouveauModifie do
     end
   end
 
-  # TODO https://github.com/etalab/rncs_worker_api_entreprise/issues/39
   context 'when the related dossier is not found' do
-    it 'returns a warning message' do
-      warning_msg = subject[:warning]
-
-      expect(warning_msg).to eq("The dossier (code_greffe: #{data[:code_greffe]}, numero_gestion: #{data[:numero_gestion]}) is not found. The representant (id_representant: #{data[:id_representant]}, qualite: #{data[:qualite]}) is not imported.")
-    end
-
-    it { is_expected.to be_success }
+    it_behaves_like 'related dossier not found'
   end
 end

--- a/spec/support/shared_examples/create_record.rb
+++ b/spec/support/shared_examples/create_record.rb
@@ -1,3 +1,4 @@
+# https://github.com/etalab/rncs_worker_api_entreprise/issues/39
 shared_examples 'related dossier not found' do
   let(:record_data) do
     {

--- a/spec/support/shared_examples/create_record.rb
+++ b/spec/support/shared_examples/create_record.rb
@@ -16,3 +16,25 @@ shared_examples 'related dossier not found' do
     expect(error_msg).to eq('The dossier (code_greffe: 9001, numero_gestion: 2016A10937) is not found. Aborting...')
   end
 end
+
+# The case is different for a PM or a PP : if a PM or PP is present but not
+# its related dossier, an error happened because those records are supposed
+# to be the same line in the CSV file.
+shared_examples 'related dossier not found (for PM and PP)' do
+  let(:record_data) do
+    {
+      code_greffe: '9001',
+      numero_gestion: '2016A10937',
+    }
+  end
+
+  subject { described_class.call(data: record_data) }
+
+  it { is_expected.to be_failure }
+
+  it 'returns an warning message' do
+    error_msg = subject[:error]
+
+    expect(error_msg).to eq('The dossier (code_greffe: 9001, numero_gestion: 2016A10937) is not found. Aborting...')
+  end
+end

--- a/spec/support/shared_examples/create_record.rb
+++ b/spec/support/shared_examples/create_record.rb
@@ -8,10 +8,10 @@ shared_examples 'related dossier not found' do
 
   subject { described_class.call(data: record_data) }
 
-  it { is_expected.to be_failure }
+  it { is_expected.to be_success }
 
-  it 'returns an error message' do
-    error_msg = subject[:error]
+  it 'returns an warning message' do
+    error_msg = subject[:warning]
 
     expect(error_msg).to eq('The dossier (code_greffe: 9001, numero_gestion: 2016A10937) is not found. Aborting...')
   end

--- a/spec/support/shared_examples/create_record.rb
+++ b/spec/support/shared_examples/create_record.rb
@@ -13,7 +13,7 @@ shared_examples 'related dossier not found' do
   it 'returns an warning message' do
     error_msg = subject[:warning]
 
-    expect(error_msg).to eq('The dossier (code_greffe: 9001, numero_gestion: 2016A10937) is not found. Aborting...')
+    expect(error_msg).to eq('The dossier (code_greffe: 9001, numero_gestion: 2016A10937) is not found. The line is ignored and not imported...')
   end
 end
 


### PR DESCRIPTION
### Contenu de la PR 
Ne pas tenir comptes des représentants, établissements ou observations, qu'ils soient créés ou mis à jour, lorsque l'identifiant de la PM ou PP est inconnu en base de données. La ligne est ignorée, le cas est loggé et l'import continue.

Voir #39.